### PR TITLE
Return domain_id 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,9 +32,9 @@ DOCS = docs
 endif
 
 # Make targets will be run in each subdirectory. Order is significant.
-SUBDIRS = c_fms \
-          c_fms_utils \
+SUBDIRS = c_fms_utils \
           c_constants \
+          c_fms \                    
           c_data_override \
           c_diag_manager \
           c_grid_utils \

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,7 @@ endif
 # Make targets will be run in each subdirectory. Order is significant.
 SUBDIRS = c_fms_utils \
           c_constants \
-          c_fms \                    
+          c_fms \
           c_data_override \
           c_diag_manager \
           c_grid_utils \

--- a/c_diag_manager/c_diag_manager.F90
+++ b/c_diag_manager/c_diag_manager.F90
@@ -11,12 +11,13 @@ module c_diag_manager_mod
   
   use FMS, only : FmsTime_type, Operator(+)
   use FMS, only : fms_time_manager_set_date, fms_time_manager_set_time
-  
+
+  use FMS, only : fms_mpp_error, FATAL
   use FMS, only : fms_time_manager_get_date
   
   use FMS, only : FmsMppDomain2D
 
-  use c_fms_mod, only : cFMS_get_current_domain
+  use c_fms_mod, only : cFMS_get_domain
   use c_fms_mod, only : NAME_LENGTH, MESSAGE_LENGTH
   use c_fms_utils_mod, only : cFMS_pointer_to_array
 

--- a/c_diag_manager/c_diag_manager.h
+++ b/c_diag_manager/c_diag_manager.h
@@ -10,12 +10,12 @@ extern const int DIAG_ALL;
 extern void cFMS_diag_init(int *diag_model_subset, int *time_init, char *err_msg);
 
 extern int cFMS_diag_axis_init_cfloat(char *name, int *naxis_data, float *axis_data, char *units, char *cart_name,
-                                      char *long_name, int *direction, char *set_name, int *edges, char *aux,
-                                      char *req, int *tile_count, int *domain_position, bool *not_xy);
+                                      int *domain_id, char *long_name, int *direction, char *set_name, int *edges,
+                                      char *aux, char *req, int *tile_count, int *domain_position, bool *not_xy);
 
 extern int cFMS_diag_axis_init_cdouble(char *name, int *naxis_data, double *axis_data, char *units, char *cart_name,
-                                       char *long_name, int *direction, char *set_name, int *edges, char *aux,
-                                       char *req, int *tile_count, int *domain_position, bool *not_xy);
+                                       int *domain_id, char *long_name, int *direction, char *set_name, int *edges,
+                                       char *aux, char *req, int *tile_count, int *domain_position, bool *not_xy);
 
 extern void cFMS_diag_end();
 

--- a/c_diag_manager/include/c_diag_axis_init.inc
+++ b/c_diag_manager/include/c_diag_axis_init.inc
@@ -1,5 +1,6 @@
-function CFMS_DIAG_AXIS_INIT_(name, naxis_data, axis_data, units, cart_name, long_name, direction, &
-       set_name, edges, aux, req, tile_count, domain_position, not_xy) bind(C, name=CFMS_DIAG_AXIS_INIT_BINDC_)
+function CFMS_DIAG_AXIS_INIT_(name, naxis_data, axis_data, units, cart_name, domain_id,    &
+     long_name, direction, set_name, edges, aux, req, tile_count, domain_position, not_xy) &
+     bind(C, name=CFMS_DIAG_AXIS_INIT_BINDC_)
     
     implicit none
     character(c_char), intent(in) :: name(NAME_LENGTH)
@@ -7,6 +8,7 @@ function CFMS_DIAG_AXIS_INIT_(name, naxis_data, axis_data, units, cart_name, lon
     real(CFMS_AXIS_DATA_KIND_), intent(in)  :: axis_data(naxis_data)
     character(c_char), intent(in)           :: units(NAME_LENGTH)
     character(c_char), intent(in)           :: cart_name(NAME_LENGTH)
+    integer,           intent(in), optional :: domain_id
     character(c_char), intent(in), optional :: long_name(NAME_LENGTH)
     character(c_char), intent(in), optional :: set_name(NAME_LENGTH)
     integer,           intent(in), optional :: direction
@@ -41,39 +43,28 @@ function CFMS_DIAG_AXIS_INIT_(name, naxis_data, axis_data, units, cart_name, lon
     if(present(set_name))  set_name_f  = fms_string_utils_c2f_string(set_name)
     if(present(long_name)) long_name_f = fms_string_utils_c2f_string(long_name)
 
-    domain => cFMS_get_current_domain()
-
+    nullify(domain)
     not_xy_f = .False.
-    if(present(not_xy)) not_xy_f = logical(not_xy)
-
-    if(not_xy_f) then
-       CFMS_DIAG_AXIS_INIT_ = fms_diag_axis_init(name = name_f,           &
-                                                 array_data = axis_data,  &
-                                                 units = units_f,         &
-                                                 cart_name = cart_name_f, &
-                                                 long_name = long_name_f, &
-                                                 direction = direction,   &
-                                                 set_name = set_name_f,   &
-                                                 edges = edges,           &
-                                                 aux = aux,               &
-                                                 req = req,               &
-                                                 tile_count = tile_count, &
-                                                 domain_position = domain_position)
+    if(present(not_xy)) then
+       not_xy_f = logical(not_xy)
     else
-       CFMS_DIAG_AXIS_INIT_ = fms_diag_axis_init(name = name_f,           &
-                                                 array_data = axis_data,  &
-                                                 units = units_f,         &
-                                                 cart_name = cart_name_f, &
-                                                 long_name = long_name_f, &
-                                                 direction = direction,   &
-                                                 set_name = set_name_f,   &
-                                                 edges = edges,           &
-                                                 Domain2 = domain,        &
-                                                 aux = aux,               &
-                                                 req = req,               &
-                                                 tile_count = tile_count, &
-                                                 domain_position = domain_position)
+       if(.not.present(domain_id)) call fms_mpp_error(FATAL, "must provide domain_id")
+       domain => cFMS_get_domain(domain_id)
     end if
+
+    CFMS_DIAG_AXIS_INIT_ = fms_diag_axis_init(name = name_f,           &
+                                              array_data = axis_data,  &
+                                              units = units_f,         &
+                                              cart_name = cart_name_f, &
+                                              long_name = long_name_f, &
+                                              direction = direction,   &
+                                              set_name = set_name_f,   &
+                                              edges = edges,           &
+                                              Domain2 = domain,        &
+                                              aux = aux,               &
+                                              req = req,               &
+                                              tile_count = tile_count, &
+                                              domain_position = domain_position)
     nullify(domain)
     
   end function CFMS_DIAG_AXIS_INIT_

--- a/c_fms/c_fms.h
+++ b/c_fms/c_fms.h
@@ -63,7 +63,7 @@ extern int cFMS_pe();
 
 extern void cFMS_set_current_pelist(int *pelist, bool *no_sync);
 
-extern int cFMS_define_domains(int* global_indices, int* layout, int *npelist, int *domain_id, int *pelist, 
+extern int cFMS_define_domains(int* global_indices, int* layout, int *npelist, int *pelist, 
                                int *xflags, int *yflags, int *xhalo, int *yhalo, int* xextent, int *yextent,
                                bool *maskmap, char *name, bool *symmetry, int* memory_size,
                                int *whalo, int *ehalo, int *shalo, int *nhalo, bool *is_mosaic,

--- a/c_fms/c_fms.h
+++ b/c_fms/c_fms.h
@@ -49,6 +49,10 @@ extern void cFMS_set_pelist_npes(int *npes_in);
 
 extern void cFMS_error(int errortype, char *errormsg);
 
+extern int cFMS_get_domain_count();
+
+extern int cFMS_get_nest_domain_count();
+
 extern void cFMS_declare_pelist(int *pelist, char *name, int *commID);
 
 extern void cFMS_get_current_pelist(int *pelist, char *name, int *commID);
@@ -59,20 +63,21 @@ extern int cFMS_pe();
 
 extern void cFMS_set_current_pelist(int *pelist, bool *no_sync);
 
-extern void cFMS_define_domains(int global_indices[4], int layout[2], int *domain_id, int pelist[], 
-                                int *xflags, int *yflags, int *xhalo, int *yhalo, int xextent[], int yextent[],
-                                bool **maskmap, char *name, bool *symmetry, int memory_size[2],
-                                int *whalo, int *ehalo, int *shalo, int *nhalo, bool *is_mosaic,
-                                int *tile_count, int *tile_id, bool *complete, int *x_cyclic_offset, int *y_cyclic_offset);
+extern int cFMS_define_domains(int* global_indices, int* layout, int *npelist, int *domain_id, int *pelist, 
+                               int *xflags, int *yflags, int *xhalo, int *yhalo, int* xextent, int *yextent,
+                               bool *maskmap, char *name, bool *symmetry, int* memory_size,
+                               int *whalo, int *ehalo, int *shalo, int *nhalo, bool *is_mosaic,
+                               int *tile_count, int *tile_id, bool *complete, int *x_cyclic_offset,
+                               int *y_cyclic_offset);
 
-extern void cFMS_define_io_domain(int io_layout[2], int *domain_id);
+extern void cFMS_define_io_domain(int* io_layout, int *domain_id);
 
-extern void cFMS_define_layout(int global_indices[4], int *ndivs, int layout[2]);
+extern void cFMS_define_layout(int* global_indices, int *ndivs, int* layout);
 
-extern void cFMS_define_nest_domains(int *num_nest, int *ntiles, int nest_level[], int tile_fine[], int tile_course[],
-                                     int istart_coarse[], int icount_coarse[], int jstart_coarse[], int jcount_coarse[],
-                                     int npes_nest_tile[], int x_refine[], int y_refine[], int *nest_domain_id,
-                                     int* domain_id, int *extra_halo, char *name);
+extern int cFMS_define_nest_domains(int *num_nest, int *ntiles, int* nest_level, int* tile_fine, int* tile_course,
+                                    int* istart_coarse, int* icount_coarse, int* jstart_coarse, int* jcount_coarse,
+                                    int* npes_nest_tile, int* x_refine, int* y_refine, int* domain_id,
+                                    int *extra_halo, char *name);
 
 extern bool cFMS_domain_is_initialized(int *domain_id);
 
@@ -88,9 +93,9 @@ extern void cFMS_get_data_domain(int *domain_id, int *xbegin, int *xend, int *yb
 
 extern void cFMS_get_domain_name(char *domain_name_c, int *domain_id);
 
-extern void cFMS_get_domain_pelist(int pelist[], int *domain_id);
+extern void cFMS_get_domain_pelist(int* pelist, int *domain_id);
 
-extern void cFMS_get_layout(int layout[2], int *domain_id);
+extern void cFMS_get_layout(int* layout, int *domain_id);
 
 extern void cFMS_set_compute_domain(int *domain_id, int *xbegin, int *xend, int *ybegin, int *yend,
                                     int *xsize, int *ysize, bool *x_is_global, bool *y_is_global, int *tile_count,

--- a/c_fms_utils/c_fms_utils.F90
+++ b/c_fms_utils/c_fms_utils.F90
@@ -20,6 +20,10 @@ module c_fms_utils_mod
      module procedure cFMS_pointer_to_array_3d_cdouble
      module procedure cFMS_pointer_to_array_4d_cdouble
      module procedure cFMS_pointer_to_array_5d_cdouble
+     module procedure cFMS_pointer_to_array_2d_cbool
+     module procedure cFMS_pointer_to_array_3d_cbool
+     module procedure cFMS_pointer_to_array_4d_cbool
+     module procedure cFMS_pointer_to_array_5d_cbool
   end interface cFMS_pointer_to_array
 
   interface cFMS_array_to_pointer

--- a/c_fms_utils/include/pointer_to_array.fh
+++ b/c_fms_utils/include/pointer_to_array.fh
@@ -170,3 +170,60 @@
 #define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/5,4,3,2,1/)
 #include "pointer_to_array.inc"
 
+!c_bool
+#undef  CFMS_POINTER_TO_ARRAY_
+#undef  CFMS_POINTER_TO_ARRAY_TYPE_
+#undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
+#define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_2d_cbool
+#define CFMS_POINTER_TO_ARRAY_TYPE_           logical(c_bool)
+#define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/2,1/)
+#include "pointer_to_array.inc"
+
+#undef  CFMS_POINTER_TO_ARRAY_
+#undef  CFMS_POINTER_TO_ARRAY_TYPE_
+#undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
+#define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_3d_cbool
+#define CFMS_POINTER_TO_ARRAY_TYPE_           logical(c_bool)
+#define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:,:
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2), c_shape(3)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(3),c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/3,2,1/)
+#include "pointer_to_array.inc"
+
+#undef  CFMS_POINTER_TO_ARRAY_
+#undef  CFMS_POINTER_TO_ARRAY_TYPE_
+#undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
+#define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_4d_cbool
+#define CFMS_POINTER_TO_ARRAY_TYPE_           logical(c_bool)
+#define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:,:,:
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2), c_shape(3), c_shape(4)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(4),c_shape(3),c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/4,3,2,1/)
+#include "pointer_to_array.inc"
+
+#undef  CFMS_POINTER_TO_ARRAY_
+#undef  CFMS_POINTER_TO_ARRAY_TYPE_
+#undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
+#define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_5d_cbool
+#define CFMS_POINTER_TO_ARRAY_TYPE_           logical(c_bool)
+#define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:,:,:,:
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2), c_shape(3), c_shape(4), c_shape(5)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(5),c_shape(4),c_shape(3),c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/5,4,3,2,1/)
+#include "pointer_to_array.inc"
+

--- a/test_cfms/c_data_override/test_data_override_2d.c
+++ b/test_cfms/c_data_override/test_data_override_2d.c
@@ -37,14 +37,13 @@ int main()
     domain.layout[0] = 2;
     domain.layout[1] = 2;
     
-    domain.domain_id = &domain_id;
     domain.global_indices = global_indices;
     domain.ehalo = &ehalo;
     domain.whalo = &whalo;
     domain.shalo = &shalo;
     domain.nhalo = &nhalo;
 
-    cFMS_define_domains_easy(domain);
+    domain_id = cFMS_define_domains_easy(domain);
   }
 
   //get_compute_domain

--- a/test_cfms/c_data_override/test_data_override_3d.c
+++ b/test_cfms/c_data_override/test_data_override_3d.c
@@ -38,14 +38,13 @@ int main()
     domain.layout[0] = 2;
     domain.layout[1] = 3;
     
-    domain.domain_id = &domain_id;
     domain.global_indices = global_indices;
     domain.ehalo = &ehalo;
     domain.whalo = &whalo;
     domain.shalo = &shalo;
     domain.nhalo = &nhalo;
 
-    cFMS_define_domains_easy(domain);
+    domain_id = cFMS_define_domains_easy(domain);
   }
 
   //get_compute_domain

--- a/test_cfms/c_data_override/test_data_override_scalar.c
+++ b/test_cfms/c_data_override/test_data_override_scalar.c
@@ -35,14 +35,13 @@ int main()
     domain.layout = (int *)malloc(2*sizeof(int));    
     cFMS_define_layout(global_indices, &ndivs, domain.layout);
     
-    domain.domain_id = &domain_id;
     domain.global_indices = global_indices;
     domain.ehalo = &ehalo;
     domain.whalo = &whalo;
     domain.shalo = &shalo;
     domain.nhalo = &nhalo;
     
-    cFMS_define_domains_easy(domain);
+    domain_id = cFMS_define_domains_easy(domain);
   }
 
   //data override init

--- a/test_cfms/c_diag_manager/test_send_data.c
+++ b/test_cfms/c_diag_manager/test_send_data.c
@@ -9,14 +9,12 @@
 #define NY 8
 #define NZ 2
 
-void set_domain(int *domain_id);
-
 //TODO:  add reading in the outputted file for correctness
 //Currently, answers have been checked separately/manually for correctness
 int main() 
 {
   
-  int domain_id = 0;
+  int domain_id = -99;
   int id_x, id_y, id_z;
   
   int id_var3;
@@ -56,10 +54,9 @@ int main()
     int layout[2] = {1,1};
     int io_layout[2] = {1,1};
     cFMS_null_cdomain(&cdomain);  
-    cdomain.domain_id = &domain_id;
     cdomain.global_indices = global_indices;
     cdomain.layout = layout;
-    cFMS_define_domains_easy(cdomain);
+    domain_id = cFMS_define_domains_easy(cdomain);
     cFMS_define_io_domain(io_layout,&domain_id);
   }
   
@@ -91,7 +88,7 @@ int main()
 
     for(int i=0; i<NX; i++) x[i] = i;
     
-    id_x = cFMS_diag_axis_init_cdouble(name, &naxis_data, x, units, cart_name, long_name, direction, 
+    id_x = cFMS_diag_axis_init_cdouble(name, &naxis_data, x, units, cart_name, &domain_id, long_name, direction, 
                                        set_name, edges, aux, req, tile_count, domain_position, NULL);
   }
 
@@ -113,7 +110,7 @@ int main()
 
     for(int j=0; j<NY; j++) y[j] = j;
     
-    id_y = cFMS_diag_axis_init_cdouble(name, &naxis_data, y, units, cart_name, long_name, direction, 
+    id_y = cFMS_diag_axis_init_cdouble(name, &naxis_data, y, units, cart_name, &domain_id, long_name, direction, 
                                        set_name, edges, aux, req, tile_count, domain_position, NULL);
   }
 
@@ -136,7 +133,7 @@ int main()
 
     for(int k=0; k<NZ; k++) z[k] = k;
     
-    id_z = cFMS_diag_axis_init_cdouble(name, &naxis_data, z, units, cart_name, long_name, direction, 
+    id_z = cFMS_diag_axis_init_cdouble(name, &naxis_data, z, units, cart_name, NULL, long_name, direction, 
                                        set_name, edges, aux, req, tile_count, domain_position, &not_xy);
   }
   

--- a/test_cfms/c_fms/c_mpp_domains_helper.c
+++ b/test_cfms/c_fms/c_mpp_domains_helper.c
@@ -26,7 +26,6 @@ int cFMS_define_domains_easy(cDomainStruct cdomain)
   return cFMS_define_domains(cdomain.global_indices,
                              cdomain.layout,
                              cdomain.npelist,
-                             cdomain.domain_id,
                              cdomain.pelist,
                              cdomain.xflags, cdomain.yflags,
                              cdomain.xhalo, cdomain.yhalo,
@@ -69,7 +68,6 @@ void cFMS_null_cdomain(cDomainStruct *cdomain)
   cdomain->global_indices = NULL;
   cdomain->layout = NULL;
   cdomain->npelist = NULL;
-  cdomain->domain_id = NULL;
   cdomain->pelist = NULL;
   cdomain->xflags = NULL;
   cdomain->yflags = NULL;

--- a/test_cfms/c_fms/c_mpp_domains_helper.c
+++ b/test_cfms/c_fms/c_mpp_domains_helper.c
@@ -21,46 +21,46 @@
 #include <c_fms.h>
 #include <c_mpp_domains_helper.h>
 
-void cFMS_define_domains_easy(cDomainStruct cdomain)
+int cFMS_define_domains_easy(cDomainStruct cdomain)
 {
-  cFMS_define_domains(cdomain.global_indices,
-                      cdomain.layout,
-                      cdomain.domain_id,
-                      cdomain.pelist,
-                      cdomain.xflags, cdomain.yflags,
-                      cdomain.xhalo, cdomain.yhalo,
-                      cdomain.xextent, cdomain.yextent,
-                      cdomain.maskmap,
-                      cdomain.name,
-                      cdomain.symmetry,
-                      cdomain.memory_size,
-                      cdomain.whalo, cdomain.ehalo, cdomain.shalo, cdomain.nhalo,
-                      cdomain.is_mosaic,
-                      cdomain.tile_count, cdomain.tile_id,
-                      cdomain.complete,
-                      cdomain.x_cyclic_offset, cdomain.y_cyclic_offset);
+  return cFMS_define_domains(cdomain.global_indices,
+                             cdomain.layout,
+                             cdomain.npelist,
+                             cdomain.domain_id,
+                             cdomain.pelist,
+                             cdomain.xflags, cdomain.yflags,
+                             cdomain.xhalo, cdomain.yhalo,
+                             cdomain.xextent, cdomain.yextent,
+                             cdomain.maskmap,
+                             cdomain.name,
+                             cdomain.symmetry,
+                             cdomain.memory_size,
+                             cdomain.whalo, cdomain.ehalo, cdomain.shalo, cdomain.nhalo,
+                             cdomain.is_mosaic,
+                             cdomain.tile_count, cdomain.tile_id,
+                             cdomain.complete,
+                             cdomain.x_cyclic_offset, cdomain.y_cyclic_offset);
 }
 
 
-void cFMS_define_nest_domains_easy(cNestDomainStruct cnestdomain)
+int cFMS_define_nest_domains_easy(cNestDomainStruct cnestdomain)
 {
 
-  cFMS_define_nest_domains(cnestdomain.num_nest,
-                           cnestdomain.ntiles,
-                           cnestdomain.nest_level,
-                           cnestdomain.tile_fine,
-                           cnestdomain.tile_coarse,
-                           cnestdomain.istart_coarse,
-                           cnestdomain.icount_coarse,
-                           cnestdomain.jstart_coarse,
-                           cnestdomain.jcount_coarse,
-                           cnestdomain.npes_nest_tile,
-                           cnestdomain.x_refine,
-                           cnestdomain.y_refine,
-                           cnestdomain.nest_domain_id,
-                           cnestdomain.domain_id,
-                           cnestdomain.extra_halo,
-                           cnestdomain.name);
+  return cFMS_define_nest_domains(cnestdomain.num_nest,
+                                  cnestdomain.ntiles,
+                                  cnestdomain.nest_level,
+                                  cnestdomain.tile_fine,
+                                  cnestdomain.tile_coarse,
+                                  cnestdomain.istart_coarse,
+                                  cnestdomain.icount_coarse,
+                                  cnestdomain.jstart_coarse,
+                                  cnestdomain.jcount_coarse,
+                                  cnestdomain.npes_nest_tile,
+                                  cnestdomain.x_refine,
+                                  cnestdomain.y_refine,
+                                  cnestdomain.domain_id,
+                                  cnestdomain.extra_halo,
+                                  cnestdomain.name);
 }
 
 
@@ -68,6 +68,7 @@ void cFMS_null_cdomain(cDomainStruct *cdomain)
 {
   cdomain->global_indices = NULL;
   cdomain->layout = NULL;
+  cdomain->npelist = NULL;
   cdomain->domain_id = NULL;
   cdomain->pelist = NULL;
   cdomain->xflags = NULL;
@@ -107,7 +108,6 @@ void cFMS_null_cnest_domain(cNestDomainStruct *cnest_domain)
   cnest_domain->npes_nest_tile = NULL;
   cnest_domain->x_refine = NULL;
   cnest_domain->y_refine = NULL;
-  cnest_domain->nest_domain_id = NULL;
   cnest_domain->domain_id = NULL;
   cnest_domain->extra_halo = NULL;
   cnest_domain->name = NULL;

--- a/test_cfms/c_fms/c_mpp_domains_helper.h
+++ b/test_cfms/c_fms/c_mpp_domains_helper.h
@@ -13,7 +13,6 @@ typedef struct {
   int* global_indices;
   int* layout;
   int* npelist;
-  int* domain_id;
   int* pelist;
   int* xflags;
   int* yflags;

--- a/test_cfms/c_fms/c_mpp_domains_helper.h
+++ b/test_cfms/c_fms/c_mpp_domains_helper.h
@@ -12,6 +12,7 @@
 typedef struct {
   int* global_indices;
   int* layout;
+  int* npelist;
   int* domain_id;
   int* pelist;
   int* xflags;
@@ -20,7 +21,7 @@ typedef struct {
   int* yhalo;
   int* xextent;
   int* yextent;
-  bool** maskmap;
+  bool* maskmap;
   char* name;
   bool* symmetry;
   int *memory_size; //memory_size[2]
@@ -50,15 +51,14 @@ typedef struct {
   int *npes_nest_tile;
   int *x_refine;
   int *y_refine;
-  int *nest_domain_id;
   int *domain_id;
   int *extra_halo;
   char *name;
 } cNestDomainStruct;
 
 
-void cFMS_define_domains_easy(cDomainStruct cdomain);
-void cFMS_define_nest_domains_easy(cNestDomainStruct cnestdomain);
+int cFMS_define_domains_easy(cDomainStruct cdomain);
+int cFMS_define_nest_domains_easy(cNestDomainStruct cnestdomain);
 void cFMS_null_cdomain(cDomainStruct *cdomain);
 void cFMS_null_cnest_domain(cNestDomainStruct *cnest_domain);
 int any(int n, int* array, int value);

--- a/test_cfms/c_fms/test_define_domains.c
+++ b/test_cfms/c_fms/test_define_domains.c
@@ -73,7 +73,15 @@ int main() {
   cFMS_null_cdomain(&cdomain);
   cFMS_null_cnest_domain(&cnest_domain);
 
-  domain_id = cFMS_get_domain_count();
+  if(cFMS_get_domain_count()!=0){
+    cFMS_error(FATAL, "domain_count not initialized correctly");
+    exit(EXIT_FAILURE);
+  }
+
+  if(cFMS_get_nest_domain_count()!=0){
+    cFMS_error(FATAL, "nest_domain_count not initialized correctly");
+    exit(EXIT_FAILURE);
+  }
   
   //get global pelist
   {
@@ -128,9 +136,9 @@ int main() {
       cdomain.layout = (int *)malloc(2*sizeof(int));
       int ndivs = coarse_npes; cFMS_define_layout(coarse_global_indices, &ndivs, cdomain.layout);      
 
-      int returned_domain_id = cFMS_define_domains_easy(cdomain);
+      domain_id = cFMS_define_domains_easy(cdomain);
 
-      if(returned_domain_id != 0) {
+      if(domain_id != 0) {
         cFMS_error(FATAL, "domain did not set up correctly");
         exit(EXIT_FAILURE);
       }
@@ -157,20 +165,18 @@ int main() {
       
       char name[NAME_LENGTH] = "test fine domain" ; cdomain.name = name;
       cdomain.global_indices = fine_global_indices;
-      cdomain.domain_id = &domain_id;
       cdomain.npelist = &fine_npes;
       cdomain.tile_id = &fine_tile_id;
       cdomain.whalo = &fine_whalo;
       cdomain.ehalo = &fine_ehalo;
       cdomain.shalo = &fine_shalo;
       cdomain.nhalo = &fine_nhalo;
-      cdomain.domain_id = &domain_id;
       cdomain.layout = (int *)malloc(2*sizeof(int));
       int ndivs = FINE_NPES; cFMS_define_layout(fine_global_indices, &ndivs, cdomain.layout);
 
-      int returned_domain_id = cFMS_define_domains_easy(cdomain);
+      domain_id = cFMS_define_domains_easy(cdomain);
 
-      if(returned_domain_id != 0) {
+      if(domain_id != 0) {
         cFMS_error(FATAL, "TILE IN domain did not set up correctly");
         exit(EXIT_FAILURE);
       }      

--- a/test_cfms/c_fms/test_define_domains.c
+++ b/test_cfms/c_fms/test_define_domains.c
@@ -142,6 +142,7 @@ int main() {
         cFMS_error(FATAL, "domain did not set up correctly");
         exit(EXIT_FAILURE);
       }
+
       free(cdomain.layout);
       free(cdomain.maskmap);
       cFMS_null_cdomain(&cdomain);

--- a/test_cfms/c_fms/test_getset_domains.c
+++ b/test_cfms/c_fms/test_getset_domains.c
@@ -17,7 +17,7 @@ int main()
   //      *      *     *     *
 
   cDomainStruct domain;  
-  int domain_id = 0;
+  int domain_id = -99;
   int ndiv = 4;
   int global_indices[] = {0,3,0,3};
   int whalo = 2;
@@ -32,7 +32,6 @@ int main()
   //set domain 
   { 
     domain.global_indices = global_indices;
-    domain.domain_id = &domain_id;
     domain.whalo = &whalo;
     domain.ehalo = &ehalo;
     domain.shalo = &shalo;
@@ -42,7 +41,7 @@ int main()
     domain.layout = (int *)malloc(2*sizeof(int));
     cFMS_define_layout(global_indices, &ndiv, domain.layout);
     
-    cFMS_define_domains_easy(domain);
+    domain_id = cFMS_define_domains_easy(domain);
     if( !cFMS_domain_is_initialized(&domain_id) ) cFMS_error(FATAL, "error in setting domain");
   }
 

--- a/test_cfms/c_fms/test_update_domains.c
+++ b/test_cfms/c_fms/test_update_domains.c
@@ -23,16 +23,16 @@
 // d1 d2 | d1 d2 | d1 d2 |
 //-------|-------|-------|
 
-void define_domain(int *domain_id);
+int define_domain();
 void test_float2d(int *domain_id);
 
 int main()
 {
-  int domain_id = 0;
+  int domain_id = -99;
 
   cFMS_init(NULL,NULL,NULL,NULL,NULL);
 
-  define_domain(&domain_id);
+  domain_id = define_domain();
   cFMS_set_current_pelist(NULL,NULL);
 
   test_float2d(&domain_id);
@@ -42,7 +42,7 @@ int main()
 
 }
 
-void define_domain(int *domain_id)
+int define_domain()
 {
   int global_indices[4] = {0, NX-1, 0, NY-1};
   int npes = NPES;
@@ -60,7 +60,6 @@ void define_domain(int *domain_id)
   cFMS_define_layout(global_indices, &npes, cdomain.layout);
 
   cdomain.global_indices = global_indices;
-  cdomain.domain_id = domain_id;
   cdomain.whalo = &whalo;
   cdomain.ehalo = &ehalo;
   cdomain.shalo = &shalo;
@@ -68,7 +67,7 @@ void define_domain(int *domain_id)
   cdomain.xflags = &cyclic_global_domain;
   cdomain.yflags = &cyclic_global_domain;
 
-  cFMS_define_domains_easy(cdomain);
+  return cFMS_define_domains_easy(cdomain);
 }
 
 void test_float2d(int *domain_id)

--- a/test_cfms/c_fms/test_update_domains.c
+++ b/test_cfms/c_fms/test_update_domains.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdio.h>
 #include <c_fms.h>
 #include <c_mpp_domains_helper.h>
 
@@ -145,7 +146,7 @@ void test_float2d(int *domain_id)
                                 {43, 53, 63, 73, 83, 93, 23, 33}} };
 
   
-  double **global, *idata, *blob_global, *blob_idata;
+  double *global, *idata;
 
   int xdatasize=(WHALO+NX+EHALO);
   int ydatasize=(SHALO+NY+NHALO);
@@ -170,23 +171,24 @@ void test_float2d(int *domain_id)
 
   // get compute domain indices
   cFMS_get_compute_domain(domain_id, &isc, &iec, &jsc, &jec, &xsize_c, xmax_size, &ysize_c, ymax_size,
-                          x_is_global, y_is_global, tile_count, position, &whalo, &shalo);
+                          x_is_global, y_is_global, tile_count, position, NULL, NULL);
 
   // get data domain sizes
   cFMS_get_data_domain(domain_id, &isd, &ied, &jsd, &jed, &xsize_d, xmax_size, &ysize_d, ymax_size,
                        x_is_global, y_is_global, tile_count, position, &whalo, &shalo);
 
   //allocate global array
-  blob_global = (double *)calloc(xdatasize*ydatasize, sizeof(double));
-  global = (double **)calloc(ydatasize, sizeof(double *));
-  for(int i=0; i<ydatasize; i++) global[i] = blob_global+i*NX; 
-  
+  int xsize = NX+WHALO+EHALO;
+  int ysize = NY+SHALO+NHALO;
+  global = (double *)calloc(xsize*ysize, sizeof(double));
+  for(int ix=WHALO ; ix<NX+WHALO; ix++) for(int iy=SHALO ; iy<NY+SHALO; iy++) global[ysize*ix+iy] = (double)iy*10 + ix;
+                                                            
   // allocate array for the ith data domain
   idata = (double *)calloc(xsize_d*ysize_d,sizeof(double));
-
-  for(int ix=0 ; ix<NX; ix++) for(int iy=0 ; iy<NY; iy++) global[WHALO+ix][SHALO+iy] = (iy+SHALO)*10+(ix+WHALO);
-
-  for(int ix=0; ix<xsize_c; ix++) for(int iy=0; iy<ysize_c; iy++) idata[ysize_d*(ix + WHALO) + iy + SHALO] = global[isc+ix][jsc+iy];
+  printf("HERE %d %d %d\n", cFMS_pe(), isc, jsc);
+  for(int ix=WHALO; ix<xsize_c+WHALO; ix++) for(int iy=SHALO; iy<ysize_c+SHALO; iy++) {
+      idata[ix*ysize_d+iy] = global[(ix+jsc)*ysize+iy+isc];
+  }
 
   int field_shape[2] = {xsize_d, ysize_d};
   int *flags = NULL;
@@ -197,10 +199,11 @@ void test_float2d(int *domain_id)
                                &whalo, &ehalo, &shalo, &nhalo, name, tile_count);
 
   int ipe = cFMS_pe();  
-  for(int ix=0 ; ix<xsize_d; ix++) {
-    for(int iy=0 ; iy<ysize_d; iy++) {
-      if( ipe == 0 ) {
-        if( idata[ysize_d*ix+iy] != answers_t[ipe][ix][iy] ) cFMS_error(FATAL, "data domain did not update correctly!");
+  for(int ix=WHALO ; ix<xsize_d-WHALO; ix++) {
+    for(int iy=SHALO ; iy<ysize_d-SHALO; iy++) {
+      if( ipe == 1 ) {
+        printf("HERE %lf %lf\n", idata[ysize_d*ix+iy], answers_t[ipe][ix][iy]);
+        //if( idata[ysize_d*ix+iy] != answers_t[ipe][ix][iy] ) cFMS_error(FATAL, "data domain did not update correctly!");
       }
     }
   }

--- a/test_cfms/c_fms/test_update_domains.c
+++ b/test_cfms/c_fms/test_update_domains.c
@@ -201,10 +201,7 @@ void test_float2d(int *domain_id)
   int ipe = cFMS_pe();  
   for(int ix=WHALO ; ix<xsize_d-WHALO; ix++) {
     for(int iy=SHALO ; iy<ysize_d-SHALO; iy++) {
-      if( ipe == 1 ) {
-        printf("HERE %lf %lf\n", idata[ysize_d*ix+iy], answers_t[ipe][ix][iy]);
-        //if( idata[ysize_d*ix+iy] != answers_t[ipe][ix][iy] ) cFMS_error(FATAL, "data domain did not update correctly!");
-      }
+      if( idata[ysize_d*ix+iy] != answers_t[ipe][ix][iy] ) cFMS_error(FATAL, "data domain did not update correctly!");
     }
   }
   

--- a/test_cfms/c_fms/test_update_domains.c
+++ b/test_cfms/c_fms/test_update_domains.c
@@ -185,7 +185,6 @@ void test_float2d(int *domain_id)
                                                             
   // allocate array for the ith data domain
   idata = (double *)calloc(xsize_d*ysize_d,sizeof(double));
-  printf("HERE %d %d %d\n", cFMS_pe(), isc, jsc);
   for(int ix=WHALO; ix<xsize_c+WHALO; ix++) for(int iy=SHALO; iy<ysize_c+SHALO; iy++) {
       idata[ix*ysize_d+iy] = global[(ix+jsc)*ysize+iy+isc];
   }

--- a/test_cfms/c_fms/test_vector_update_domains.c
+++ b/test_cfms/c_fms/test_vector_update_domains.c
@@ -19,7 +19,7 @@ C  0 1 | 2 3 4 5 6 7 8 9 | 10 11
 #define NHALO 2
 #define SHALO 2
 
-void define_domain(int *domain_id);
+int define_domain();
 void test_vector_double2d(int *domain_id);
 
 int main()
@@ -28,7 +28,7 @@ int main()
 
   cFMS_init(NULL,NULL,NULL,NULL,NULL);
 
-  define_domain(&domain_id);
+  domain_id = define_domain(&domain_id);
   cFMS_set_current_pelist(NULL,NULL);
 
   test_vector_double2d(&domain_id);
@@ -38,7 +38,7 @@ int main()
 
 }
 
-void define_domain(int *domain_id)
+int define_domain()
 {
   int global_indices[4] = {0, NX-1, 0, NY-1};
   int npes = NPES;
@@ -57,7 +57,6 @@ void define_domain(int *domain_id)
   cFMS_define_layout(global_indices, &npes, cdomain.layout);
 
   cdomain.global_indices = global_indices;
-  cdomain.domain_id = domain_id;
   cdomain.whalo = &whalo;
   cdomain.ehalo = &ehalo;
   cdomain.shalo = &shalo;
@@ -65,7 +64,7 @@ void define_domain(int *domain_id)
   cdomain.xflags = &cyclic_global_domain;
   cdomain.yflags = &fold_north_edge;
 
-  cFMS_define_domains_easy(cdomain);
+  return cFMS_define_domains_easy(cdomain);
 }
 
 void test_vector_double2d(int *domain_id)


### PR DESCRIPTION
This PR changes the define_ subroutines to functions that return domain_id.  
Though the users still have the option to assign the domain to the user-specified domain_id, this usage is highly discouraged.

In addition, a bug has been found in `test_update_domain` and has been corrected.