### PR TITLE
add m4 macro and configure option to set up fms linking

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
+# debug output
 set -x
+# exit on command error
+set -e
 
 curr_dir=$PWD
 install_fms=$curr_dir/FMS/gnuFMS
@@ -14,10 +17,7 @@ make install
 cd $curr_dir
 
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$install_fms/lib"
-export FCFLAGS="$FCFLAGS -I$install_fms/include -fPIC"
-export CFLAGS="$CFLAGS -I$install_fms/include -fPIC"
-export LDFLAGS="$LDFLAGS -lFMS -L$install_fms/lib"
 
 autoreconf -iv
-./configure --prefix=$curr_dir/cgnuFMS
+./configure --with-fms=$install_fms --prefix=$curr_dir/cgnuFMS
 make check

--- a/c_constants/Makefile.am
+++ b/c_constants/Makefile.am
@@ -23,8 +23,9 @@
 # Ed Hartnett 2/22/19
 
 # Include .h and .mod files.
-AM_CPPFLAGS = -I.
-AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR)
+AM_CPPFLAGS = -I$(top_abs_srcdir)/.
+AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR) $(LIBFMS_FCFLAGS)
+AM_LDFLAGS = $(LIBFMS_LIBS)
 
 # Build these uninstalled convenience libraries.
 noinst_LTLIBRARIES = lib_c_constants.la

--- a/c_data_override/Makefile.am
+++ b/c_data_override/Makefile.am
@@ -23,8 +23,9 @@
 # Ed Hartnett 2/22/19
 
 # Include .h and .mod files.
-AM_CPPFLAGS = -I. -I./include
-AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR)
+AM_CPPFLAGS = -I${abs_top_srcdir}/c_data_override/include
+AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR) $(LIBFMS_FCFLAGS)
+AM_LDFLAGS = $(LIBFMS_LIBS)
 
 # Build these uninstalled convenience libraries.
 noinst_LTLIBRARIES = lib_c_data_override.la

--- a/c_diag_manager/Makefile.am
+++ b/c_diag_manager/Makefile.am
@@ -23,8 +23,9 @@
 # Ed Hartnett 2/22/19
 
 # Include .h and .mod files.
-AM_CPPFLAGS = -I. -I./include
-AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR)
+AM_CPPFLAGS = -I${abs_top_srcdir}/c_diag_manager/include
+AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR) $(LIBFMS_FCFLAGS)
+AM_LDFLAGS = $(LIBFMS_LIBS)
 
 # Build these uninstalled convenience libraries.
 noinst_LTLIBRARIES = lib_c_diag_manager.la

--- a/c_fms/Makefile.am
+++ b/c_fms/Makefile.am
@@ -23,8 +23,9 @@
 # Ed Hartnett 2/22/19
 
 # Include .h and .mod files.
-AM_CPPFLAGS = -I. -I./include
-AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR)
+AM_CPPFLAGS = -I${abs_top_srcdir}/c_fms/include
+AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR) $(LIBFMS_FCFLAGS)
+AM_LDFLAGS = $(LIBFMS_LIBS)
 
 # Build these uninstalled convenience libraries.
 noinst_LTLIBRARIES = lib_c_fms.la

--- a/c_fms_utils/Makefile.am
+++ b/c_fms_utils/Makefile.am
@@ -23,8 +23,9 @@
 # Ed Hartnett 2/22/19
 
 # Include .h and .mod files.
-AM_CPPFLAGS = -I. -I./include
-AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR)
+AM_CPPFLAGS = -I${abs_top_srcdir}/c_fms_utils/include
+AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR) $(LIBFMS_FCFLAGS)
+AM_LDFLAGS = $(LIBFMS_LIBS)
 
 # Build these uninstalled convenience libraries.
 noinst_LTLIBRARIES = lib_c_fms_utils.la

--- a/c_grid_utils/Makefile.am
+++ b/c_grid_utils/Makefile.am
@@ -24,7 +24,8 @@
 
 # Include .h and .mod files.
 AM_CPPFLAGS = -I. -I$(top_srcdir)/FMS/grid_utils
-AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR)
+AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR) $(LIBFMS_FCFLAGS)
+AM_LDFLAGS = $(LIBFMS_LIBS)
 
 # Build these uninstalled convenience libraries.
 noinst_LTLIBRARIES = lib_c_grid_utils.la

--- a/c_horiz_interp/Makefile.am
+++ b/c_horiz_interp/Makefile.am
@@ -23,8 +23,9 @@
 # Ed Hartnett 2/22/19
 
 # Include .h and .mod files.
-AM_CPPFLAGS = -I. -I$(top_srcdir)/FMS/horiz_interp/include -I./include
-AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR)
+AM_CPPFLAGS = -I$(abs_top_srcdir)/c_horiz_interp/include
+AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR) $(LIBFMS_FCFLAGS)
+AM_LDFLAGS = $(LIBFMS_LIBS)
 
 # Build these uninstalled convenience libraries.
 noinst_LTLIBRARIES = lib_c_horiz_interp.la

--- a/configure.ac
+++ b/configure.ac
@@ -75,30 +75,6 @@ AS_IF([test ${enable_8byte_int:-no} = yes],
   [enable_8byte_int=yes],
   [enable_8byte_int=no])
 
-# user enabled testing with input files
-AC_MSG_CHECKING([whether to enable tests with input files])
-AC_ARG_ENABLE([test-input],
-            [AS_HELP_STRING([--enable-test-input="path/to/input"],
-            [Enable tests using input netcdf files, if present in the given full directory.])])
-AC_MSG_RESULT([$enable_test_input])
-
-# require path to be given
-AS_IF([test "x$enable_test_input" = "xyes"],
-    [AC_MSG_ERROR([Test input enabled, but no directory given with --enable-test-input=/path])],
-    [AS_IF([test "x$enable_test_input" != "xno"],
-        [TEST_INPUT_PATH="$enable_test_input"],[])]
-)
-
-# if set, check directory exists
-AS_IF([test "$TEST_INPUT_PATH" = ""],
-  [],
-  [AS_IF([test -d $TEST_INPUT_PATH],[],
-    [AC_MSG_ERROR([Test input enabled, but directory $TEST_INPUT_PATH not found]) ]
-  )])
-
-# substitute path for input
-AC_SUBST([TEST_INPUT_PATH])
-
 # Does the user want to build documentation?
 AC_MSG_CHECKING([whether documentation should be built (requires doxygen)])
 AC_ARG_ENABLE([docs],
@@ -213,6 +189,16 @@ if test $hdf5_fpe_bug = yes; then
 NetCDF must be built with a HDF5 version other than 1.14.3 to support floating point exception traps.])
 fi
 
+# check if we have FMS!
+# TODO change m4 macro to default to on
+# currently the script will always fail if --with-fms is omitted
+AC_MSG_CHECKING([if FMS library is available])
+GX_LIB_FMS()
+AC_MSG_RESULT([$with_fms])
+if test "x$with_fms" = xno; then
+  AC_MSG_ERROR([No FMS library found. FMS install path should be specified via --with-fms=<path> option when configuring.])
+fi
+
 
 # Check if Fortran compiler has Cray pointer support
 GX_FC_CRAY_POINTER_FLAG()
@@ -235,7 +221,7 @@ fi
 
 # Set any required compile flags.  This will not be done if the user wants to
 # define all their own flags.
-if test $enable_setting_flags = yes; then
+if test "$enable_setting_flags" = yes; then
   # Make sure the compiler is seeing this as free-formatted, not
   # fixed-formatted, fortran code.
   AC_FC_FREEFORM()
@@ -249,7 +235,7 @@ if test $enable_setting_flags = yes; then
   fi
 
   # Builds with C data types
-  if test $enable_portable_kinds = yes; then
+  if test "$enable_portable_kinds" = yes; then
     AC_DEFINE([PORTABLE_KINDS], [1], [Set to define KIND parameters to iso_c_binding KIND parameters])
   fi
 
@@ -268,7 +254,7 @@ if test $enable_setting_flags = yes; then
   fi
 
   # Add code coverage flags
-  if test $enable_code_coverage = yes; then
+  if test "$enable_code_coverage" = yes; then
     FCFLAGS="$FCFLAGS -prof-gen=srcpos"
     CFLAGS="$CFLAGS -prof-gen=srcpos"
   fi

--- a/m4/gx_lib_fms.m4
+++ b/m4/gx_lib_fms.m4
@@ -1,0 +1,109 @@
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   GX_LIB_FMS()
+#
+# DESCRIPTION
+#
+#   This macro checks for the presence of the FMS library.  FMS is a Fortran
+#   library.  Thus, this macro runs AC_LANG_ASSERT([Fortran]) to ensure that
+#   the Fortran compiler has been set.
+#
+#   If the FMS library is found, this macro calls
+#
+#      AC_SUBST([LIBFMS_FCFLAGS])
+#      AC_SUBST([LIBFMS_LIBS])
+#
+#   It also sets
+#
+#      with_fms="yes"
+#
+#   If FMS is disabled or not found, this macro sets
+#
+#      with_fms="no"
+#
+#   Your configuration script can test $with_fms to take any further
+#   actions.
+#
+#   To use the macro, do the following in "configure.ac" before
+#   AC_OUTPUT:
+#
+#      GX_LIB_FMS()
+#
+# LICENSE
+#
+#   Copyright (c) 2025 Seth Underwood <Seth.Underwood@noaa.gov>
+#
+#   Copying and distribution of this file, with or without
+#   modification, are permitted in any medium without royalty provided
+#   the copyright notice and this notice are preserved. This file is
+#   offered as-is, without any warranty.
+
+AC_DEFUN([GX_LIB_FMS], [
+AC_LANG_ASSERT([Fortran])dnl
+AS_IF([test "x$1" = "required"],
+[AS_VAR_SET([default_with_fms], [yes])],
+[AS_VAR_SET([default_with_fms], [no])])
+
+AC_ARG_WITH([fms],
+[AS_HELP_STRING([--with-fms=[yes/no/PATH]],
+  [Use an external libFMS library, at optional PATH location (default no)])],
+  [],
+  [with_fms="$default_with_fms"])
+AS_IF([test "x$with_fms" != "xno"],
+[_GX_TEST_LIB_FMS()])dnl
+])
+
+AC_DEFUN([_GX_TEST_LIB_FMS], [
+# Check if the user supplied a path to the FMS library
+AS_IF([test "x$with_fms" != "xyes"], [_gx_lib_fms_prefix="$with_fms"])
+# Set the lib and include paths from the prefix
+AS_IF([test ! -z ${_gx_lib_fms_prefix+x}], [
+AS_VAR_SET([_gx_lib_fms_lib], [${_gx_lib_fms_prefix}/lib])
+AS_VAR_SET([_gx_lib_fms_include], [${_gx_lib_fms_prefix}/include])])
+
+# Some compilers do not correctly mangle the module routine names
+# unless the Fortran file extension is .f90.  This is a workaround for
+# that issue.  The Fortran file extension will be reverted prior to
+# returning.
+_gx_fc_lib_fms_save_srcext=$ac_ext
+AC_FC_SRCEXT([f90])
+
+# Check if the FMS Fortran module, and if it usable with the current FC compiler.
+AC_CACHE_CHECK([FMS module usability], [gx_cv_fms_mod_check],[
+_gx_fc_lib_fms_save_FCFLAGS="$FCFLAGS"
+FCFLAGS="$FCFLAGS -I$_gx_lib_fms_include"
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [use fms])],
+[AS_VAR_SET([gx_cv_fms_mod_check], [yes])],
+[AS_VAR_SET([gx_cv_fms_mod_check], [no])])
+FCFLAGS="$_gx_fc_lib_fms_save_FCFLAGS"
+])
+# Check if the FMS library is usable with the current FC compiler.
+AC_CACHE_CHECK([FMS library is available], [gx_cv_fms_lib_check],[
+_gx_fc_lib_fms_save_FCFLAGS="$FCFLAGS"
+_gx_fc_lib_fms_save_LDFLAGS="$LDFLAGS"
+_gx_fc_lib_fms_save_LIBS="$LIBS"
+FCFLAGS="$FCFLAGS -I$_gx_lib_fms_include"
+LDFLAGS="$LDFLAGS -L$_gx_lib_fms_lib"
+LIBS="$LIBS -lFMS"
+AC_LINK_IFELSE([AC_LANG_PROGRAM([], [use fms])],
+[AS_VAR_SET([gx_cv_fms_lib_check], [yes])],
+[AS_VAR_SET([gx_cv_fms_lib_check], [no])])
+FCFLAGS="$_gx_fc_lib_fms_save_FCFLAGS"
+LDFLAGS="$_gx_fc_lib_fms_save_LDFLAGS"
+LIBS="$_gx_fc_lib_fms_save_LIBS"
+])
+# Reset the Fortran file extension
+ac_ext=$_gx_fc_lib_fms_save_srcext
+# Warn if the user requested FMS, but we were unable to find a working
+# library
+AS_IF([test "$gx_cv_fms_mod_check" = "no" -o "$gx_cv_fms_lib_check" = "no"],
+[AC_MSG_WARN([Unable to find a working FMS library.  Please specify --with-fms=<LOCATION> where location is the path to the FMS library.])
+with_fms="no"],[
+# Return the variables
+with_fms="yes"
+AC_SUBST([LIBFMS_FCFLAGS], ["-I$_gx_lib_fms_include"])
+AC_SUBST([LIBFMS_LIBS], ["-L$_gx_lib_fms_lib -lFMS"])
+])
+])

--- a/test_cfms/c_data_override/Makefile.am
+++ b/test_cfms/c_data_override/Makefile.am
@@ -21,6 +21,9 @@
 # Find the needed mod and .inc files.
 AM_CPPFLAGS = -I. -I$(MODDIR) -I${top_builddir}/c_data_override \
               -I${top_builddir}/c_fms -I${top_builddir}/test_cfms/c_fms
+AM_FCFLAGS = $(LIBFMS_FCFLAGS)
+AM_LDFLAGS = $(LIBFMS_LIBS)
+
 
 # Link to the FMS library.
 LDADD = ${top_builddir}/libcFMS/libcFMS.la
@@ -38,7 +41,7 @@ test_data_override_2d_SOURCES = ../c_fms/c_mpp_domains_helper.c test_data_overri
 test_data_override_3d_SOURCES = ../c_fms/c_mpp_domains_helper.c test_data_override_3d.c
 
 test_data_override_ongrid : test_data_override_ongrid.F90
-	$(FC) $(FCFLAGS) $(LDFLAGS) test_data_override_ongrid.F90 -o test_data_override_ongrid
+	$(FC) $(FCFLAGS) $(LDFLAGS) $(LIBFMS_FCFLAGS) $(LIBFMS_LIBS) test_data_override_ongrid.F90 -o test_data_override_ongrid
 
 
 TEST_EXTENSIONS = .sh

--- a/test_cfms/c_diag_manager/Makefile.am
+++ b/test_cfms/c_diag_manager/Makefile.am
@@ -21,6 +21,8 @@
 # Find the needed mod and .inc files.
 AM_CPPFLAGS = -I. -I$(MODDIR) -I${top_builddir}/c_diag_manager \
               -I${top_builddir}/c_fms -I${top_builddir}/test_cfms/c_fms
+AM_FCFLAGS = $(LIBFMS_FCFLAGS)
+AM_LDFLAGS = $(LIBFMS_LIBS)
 
 # Link to the FMS library.
 LDADD = ${top_builddir}/libcFMS/libcFMS.la

--- a/test_cfms/c_fms/Makefile.am
+++ b/test_cfms/c_fms/Makefile.am
@@ -20,6 +20,8 @@
 
 # Find the needed mod and .inc files.
 AM_CPPFLAGS = -I. -I$(MODDIR) -I${top_builddir}/c_fms
+AM_FCFLAGS = $(LIBFMS_FCFLAGS)
+AM_LDFLAGS = $(LIBFMS_LIBS)
 
 # Link to the FMS library.
 LDADD = ${top_builddir}/libcFMS/libcFMS.la

--- a/test_cfms/c_fms_utils/Makefile.am
+++ b/test_cfms/c_fms_utils/Makefile.am
@@ -20,6 +20,8 @@
 
 # Find the needed mod and .inc files.
 AM_CPPFLAGS = -I. -I$(MODDIR) -I${top_builddir}/c_fms
+AM_FCFLAGS = $(LIBFMS_FCFLAGS)
+AM_LDFLAGS = $(LIBFMS_LIBS)
 
 # Link to the FMS library.
 LDADD = ${top_builddir}/libcFMS/libcFMS.la

--- a/test_cfms/c_grid_utils/Makefile.am
+++ b/test_cfms/c_grid_utils/Makefile.am
@@ -20,6 +20,8 @@
 
 # Find the needed mod and .inc files.
 AM_CPPFLAGS = -I. -I$(MODDIR) -I${top_builddir}/c_constants -I${top_builddir}/c_grid_utils
+AM_FCFLAGS = $(LIBFMS_FCFLAGS)
+AM_LDFLAGS = $(LIBFMS_LIBS)
 
 # Link to the FMS library.
 LDADD = ${top_builddir}/libcFMS/libcFMS.la

--- a/test_cfms/c_horiz_interp/Makefile.am
+++ b/test_cfms/c_horiz_interp/Makefile.am
@@ -22,6 +22,8 @@
 AM_CPPFLAGS = -I. -I$(MODDIR) -I${top_builddir}/c_constants -I${top_builddir}/c_grid_utils \
               -I${top_builddir}/c_horiz_interp -I${top_builddir}/c_fms \
               -I${top_builddir}/test_cfms/c_fms
+AM_FCFLAGS = $(LIBFMS_FCFLAGS)
+AM_LDFLAGS = $(LIBFMS_LIBS)
 
 # Link to the FMS library.
 LDADD = ${top_builddir}/libcFMS/libcFMS.la


### PR DESCRIPTION
Adds a m4 file from @underwoo to search for a FMS install and includes some smaller makefile.am clean up.

You can specify the fms install path with the `--with-fms=/path/` configure option