### PR TITLE
update build to compile FMS if not already installed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,12 @@ DOCS = docs
 endif
 
 # Make targets will be run in each subdirectory. Order is significant.
-SUBDIRS = c_fms_utils \
+if BUILD_FMS
+SUBDIRS = FMS
+else
+SUBDIRS =
+endif
+SUBDIRS += c_fms_utils \
           c_constants \
           c_fms \
           c_data_override \
@@ -43,8 +48,9 @@ SUBDIRS = c_fms_utils \
           test_cfms
 
 ## Build libFMS module
-AM_CPPFLAGS = -I${top_srcdir}/include
+AM_CPPFLAGS = -I${abs_top_srcdir}/include -I$(abs_top_builddir)/FMS/include
 AM_FCFLAGS = $(FC_MODINC). $(FC_MODOUT)$(MODDIR)
+AM_LDFLAGS = -L$(abs_top_builddir)/libFMS -lFMS
 
 include $(top_srcdir)/mkmods.mk
 

--- a/configure.ac
+++ b/configure.ac
@@ -38,11 +38,15 @@ AC_CANONICAL_TARGET
 
 AC_CONFIG_MACRO_DIR([m4])
 
+# needed for FMS subpackage
+AC_CONFIG_AUX_DIR([.])
+
 AM_INIT_AUTOMAKE([foreign dist-zip subdir-objects])
 
 # Set up libtool.
 LT_PREREQ([2.4])
 LT_INIT()
+
 
 # If building on a Cray PE system, check if CRAYPE_LINK_TYPE is 'static'.  If it
 # is, then disable building shared libraries.  Note, the user can still override
@@ -175,6 +179,18 @@ GX_FC_CHECK_MOD([netcdf], [], [], [AC_MSG_ERROR([Can't find the netCDF Fortran m
 GX_FORTRAN_SEARCH_LIBS([nf90_create], [netcdff], [use netcdf], [iret = nf90_create('foo.nc', 1, ncid)], [],
   [AC_MSG_ERROR([Can't find the netCDF Fortran library.  Set LDFLAGS/LIBS])])
 
+
+# Add FMS as a subpackage and set flags for the subdirectories to find it (builds on top of FMS source)
+AC_MSG_CHECKING([if FMS library is available])
+GX_LIB_FMS()
+AC_MSG_RESULT([$with_fms])
+if test "x$with_fms" = xno; then
+  AC_CONFIG_SUBDIRS([FMS])
+  AC_SUBST([LIBFMS_FCFLAGS], ["-I\$(abs_top_builddir)/FMS/include -I\$(abs_top_builddir)/FMS/.mods"])
+  AC_SUBST([LIBFMS_LIBS], ["-L\$(abs_top_builddir)/FMS/libFMS -lFMS"])
+fi
+AM_CONDITIONAL(BUILD_FMS, [test "x$with_fms" = xno])
+
 # Check if we get a floating point exception with netcdf
 # this will only get triggered if you have FPE traps enabled via FCFLAGS
 AC_MSG_CHECKING([if HDF5 version causes floating point exceptions with set flags])
@@ -189,15 +205,6 @@ if test $hdf5_fpe_bug = yes; then
 NetCDF must be built with a HDF5 version other than 1.14.3 to support floating point exception traps.])
 fi
 
-# check if we have FMS!
-# TODO change m4 macro to default to on
-# currently the script will always fail if --with-fms is omitted
-AC_MSG_CHECKING([if FMS library is available])
-GX_LIB_FMS()
-AC_MSG_RESULT([$with_fms])
-if test "x$with_fms" = xno; then
-  AC_MSG_ERROR([No FMS library found. FMS install path should be specified via --with-fms=<path> option when configuring.])
-fi
 
 
 # Check if Fortran compiler has Cray pointer support

--- a/libcFMS/Makefile.am
+++ b/libcFMS/Makefile.am
@@ -39,6 +39,10 @@ libcFMS_la_LIBADD += $(top_builddir)/c_horiz_interp/lib_c_horiz_interp.la
 libcFMS_la_LIBADD += $(top_builddir)/c_grid_utils/lib_c_grid_utils.la
 libcFMS_la_LIBADD += $(top_builddir)/c_fms_utils/lib_c_fms_utils.la
 
+libcFMS_la_LIBADD += $(abs_top_builddir)/FMS/libFMS/libFMS.la
+
+libcFMS_la_LDFLAGS += -L$(abs_top_builddir)/FMS/libFMS/
+
 libcFMS_la_SOURCES =
 
 nodist_EXTRA_libcFMS_la_SOURCES = dummy.f90

--- a/test_cfms/c_data_override/Makefile.am
+++ b/test_cfms/c_data_override/Makefile.am
@@ -19,8 +19,8 @@
 #
 
 # Find the needed mod and .inc files.
-AM_CPPFLAGS = -I. -I$(MODDIR) -I${top_builddir}/c_data_override \
-              -I${top_builddir}/c_fms -I${top_builddir}/test_cfms/c_fms
+AM_CPPFLAGS = -I. -I$(MODDIR) -I${abs_top_srcdir}/c_data_override \
+              -I${abs_top_srcdir}/c_fms -I${abs_top_srcdir}/test_cfms/c_fms
 AM_FCFLAGS = $(LIBFMS_FCFLAGS)
 AM_LDFLAGS = $(LIBFMS_LIBS)
 

--- a/test_cfms/c_diag_manager/Makefile.am
+++ b/test_cfms/c_diag_manager/Makefile.am
@@ -19,13 +19,13 @@
 #
 
 # Find the needed mod and .inc files.
-AM_CPPFLAGS = -I. -I$(MODDIR) -I${top_builddir}/c_diag_manager \
-              -I${top_builddir}/c_fms -I${top_builddir}/test_cfms/c_fms
+AM_CPPFLAGS = -I. -I$(MODDIR) -I${abs_top_srcdir}/c_diag_manager \
+              -I${abs_top_srcdir}/c_fms -I${abs_top_srcdir}/test_cfms/c_fms
 AM_FCFLAGS = $(LIBFMS_FCFLAGS)
 AM_LDFLAGS = $(LIBFMS_LIBS)
 
 # Link to the FMS library.
-LDADD = ${top_builddir}/libcFMS/libcFMS.la
+LDADD = ${abs_top_builddir}/libcFMS/libcFMS.la
 
 check_PROGRAMS = test_send_data
 

--- a/test_cfms/c_fms/Makefile.am
+++ b/test_cfms/c_fms/Makefile.am
@@ -19,12 +19,12 @@
 #
 
 # Find the needed mod and .inc files.
-AM_CPPFLAGS = -I. -I$(MODDIR) -I${top_builddir}/c_fms
+AM_CPPFLAGS = -I. -I$(MODDIR) -I${abs_top_srcdir}/c_fms
 AM_FCFLAGS = $(LIBFMS_FCFLAGS)
 AM_LDFLAGS = $(LIBFMS_LIBS)
 
 # Link to the FMS library.
-LDADD = ${top_builddir}/libcFMS/libcFMS.la
+LDADD = ${abs_top_builddir}/libcFMS/libcFMS.la
 
 check_PROGRAMS = test_define_domains \
 	test_getset_domains \

--- a/test_cfms/c_fms_utils/Makefile.am
+++ b/test_cfms/c_fms_utils/Makefile.am
@@ -19,12 +19,12 @@
 #
 
 # Find the needed mod and .inc files.
-AM_CPPFLAGS = -I. -I$(MODDIR) -I${top_builddir}/c_fms
+AM_CPPFLAGS = -I. -I$(MODDIR) -I${abs_top_srcdir}/c_fms
 AM_FCFLAGS = $(LIBFMS_FCFLAGS)
 AM_LDFLAGS = $(LIBFMS_LIBS)
 
 # Link to the FMS library.
-LDADD = ${top_builddir}/libcFMS/libcFMS.la
+LDADD = ${abs_top_builddir}/libcFMS/libcFMS.la
 
 check_PROGRAMS = test_utils
 

--- a/test_cfms/c_grid_utils/Makefile.am
+++ b/test_cfms/c_grid_utils/Makefile.am
@@ -19,12 +19,12 @@
 #
 
 # Find the needed mod and .inc files.
-AM_CPPFLAGS = -I. -I$(MODDIR) -I${top_builddir}/c_constants -I${top_builddir}/c_grid_utils
+AM_CPPFLAGS = -I. -I$(MODDIR) -I${abs_top_srcdir}/c_constants -I${abs_top_srcdir}/c_grid_utils
 AM_FCFLAGS = $(LIBFMS_FCFLAGS)
 AM_LDFLAGS = $(LIBFMS_LIBS)
 
 # Link to the FMS library.
-LDADD = ${top_builddir}/libcFMS/libcFMS.la
+LDADD = ${abs_top_builddir}/libcFMS/libcFMS.la
 
 check_PROGRAMS = test_grid_utils
 

--- a/test_cfms/c_horiz_interp/Makefile.am
+++ b/test_cfms/c_horiz_interp/Makefile.am
@@ -19,14 +19,14 @@
 #
 
 # Find the needed mod and .inc files.
-AM_CPPFLAGS = -I. -I$(MODDIR) -I${top_builddir}/c_constants -I${top_builddir}/c_grid_utils \
-              -I${top_builddir}/c_horiz_interp -I${top_builddir}/c_fms \
-              -I${top_builddir}/test_cfms/c_fms
+AM_CPPFLAGS = -I. -I$(MODDIR) -I${abs_top_srcdir}/c_constants -I${abs_top_srcdir}/c_grid_utils \
+              -I${abs_top_srcdir}/c_horiz_interp -I${abs_top_srcdir}/c_fms \
+              -I${abs_top_srcdir}/test_cfms/c_fms
 AM_FCFLAGS = $(LIBFMS_FCFLAGS)
 AM_LDFLAGS = $(LIBFMS_LIBS)
 
 # Link to the FMS library.
-LDADD = ${top_builddir}/libcFMS/libcFMS.la
+LDADD = ${abs_top_builddir}/libcFMS/libcFMS.la
 
 check_PROGRAMS = test_create_xgrid \
   test_horiz_interp_new


### PR DESCRIPTION
adds the FMS directory as a "subpackage". I set it up so that if a pre-built FMS install path is not provided via `--with-fms=path`, the configure and make for cFMS will include configuring and building original FMS as well.

Includes some changes to use the absolute path names, fixes issues when not building on top of the source directory.