### PR TITLE
Option to skip converting C-F order

### DIFF
--- a/c_data_override/c_data_override.h
+++ b/c_data_override/c_data_override.h
@@ -13,16 +13,18 @@ extern void cFMS_data_override_0d_cdouble(char *gridname, char *fieldname_code, 
                                           int *data_index);
 
 extern void cFMS_data_override_2d_cfloat(char *gridname, char *fieldname, int *data_shape, float *data,
-                                         bool *override, int *is, int *ie, int *js, int *je);
+                                         bool *override, int *is, int *ie, int *js, int *je, bool *convert_cf_order);
 
 extern void cFMS_data_override_2d_cdouble(char *gridname, char *fieldname, int *data_shape, double *data,
-                                          bool *override, int *is, int *ie, int *js, int *je);
+                                          bool *override, int *is, int *ie, int *js, int *je, bool *convert_cf_order);
 
 extern void cFMS_data_override_3d_cfloat(char *gridname, char *fieldname, int *data_shape, float *data,
-                                         bool *override, int *data_index, int *is, int *ie, int *js, int *je);
+                                         bool *override, int *data_index, int *is, int *ie, int *js,
+                                         int *je, bool *convert_cf_order);
 
 extern void cFMS_data_override_3d_cdouble(char *gridname, char *fieldname, int *data_shape, double *data,
-                                          bool *override, int *data_index, int *is, int *ie, int *js, int *je);
+                                          bool *override, int *data_index, int *is, int *ie, int *js, int *je,
+                                          bool *convet_cf_order);
 
 extern void cFMS_data_override_init(int *atm_domain_id, int *ocn_domain_id, int *ice_domain_id, int *land_domain_id,
                                     int *land_domainUG_id, int *mode);

--- a/c_data_override/include/c_data_override_2d.inc
+++ b/c_data_override/include/c_data_override_2d.inc
@@ -1,5 +1,5 @@
-subroutine CFMS_DATA_OVERRIDE_2D_(gridname, fieldname, data_shape, data, override, is, ie, js, je) &
-     bind(C, name=CFMS_DATA_OVERRIDE_2D_BINDC_)
+subroutine CFMS_DATA_OVERRIDE_2D_(gridname, fieldname, data_shape, data, override, &
+     is, ie, js, je, convert_cf_order) bind(C, name=CFMS_DATA_OVERRIDE_2D_BINDC_)
 
   implicit none
   character(c_char), intent(in) :: gridname(NAME_LENGTH)
@@ -11,6 +11,7 @@ subroutine CFMS_DATA_OVERRIDE_2D_(gridname, fieldname, data_shape, data, overrid
   integer, intent(in), optional :: ie
   integer, intent(in), optional :: js
   integer, intent(in), optional :: je
+  logical(c_bool), intent(in), optional :: convert_cf_order
 
   character(len=NAME_LENGTH-1) :: gridname_f
   character(len=NAME_LENGTH-1) :: fieldname_f
@@ -33,7 +34,7 @@ subroutine CFMS_DATA_OVERRIDE_2D_(gridname, fieldname, data_shape, data, overrid
                          ie_in = ie, &
                          je_in = je)
   
-  call cfms_array_to_pointer(data_f, data_shape, data)  
+  call cfms_array_to_pointer(data_f, data_shape, data, convert_cf_order)
   deallocate(data_f)
   
   if(present(override)) override = logical(override_f, c_bool)

--- a/c_data_override/include/c_data_override_3d.inc
+++ b/c_data_override/include/c_data_override_3d.inc
@@ -1,5 +1,5 @@
-subroutine CFMS_DATA_OVERRIDE_3D_(gridname, fieldname, data_shape, data, override, data_index, is, ie, js, je) &
-     bind(C, name=CFMS_DATA_OVERRIDE_3D_BINDC_)
+subroutine CFMS_DATA_OVERRIDE_3D_(gridname, fieldname, data_shape, data, override, &
+     data_index, is, ie, js, je, convert_cf_order) bind(C, name=CFMS_DATA_OVERRIDE_3D_BINDC_)
 
   implicit none
   character(c_char), intent(in) :: gridname(NAME_LENGTH)
@@ -12,6 +12,7 @@ subroutine CFMS_DATA_OVERRIDE_3D_(gridname, fieldname, data_shape, data, overrid
   integer, intent(in), optional :: ie
   integer, intent(in), optional :: js
   integer, intent(in), optional :: je
+  logical(c_bool), intent(in), optional :: convert_cf_order
 
   character(len=NAME_LENGTH-1) :: gridname_f
   character(len=NAME_LENGTH-1) :: fieldname_f
@@ -35,7 +36,7 @@ subroutine CFMS_DATA_OVERRIDE_3D_(gridname, fieldname, data_shape, data, overrid
                          ie_in = ie, &
                          je_in = je)
   
-  call cfms_array_to_pointer(data_f, data_shape, data)  
+  call cfms_array_to_pointer(data_f, data_shape, data, convert_cf_order)
   deallocate(data_f)
   
   if(present(override)) override = logical(override_f, c_bool)

--- a/c_diag_manager/c_diag_manager.h
+++ b/c_diag_manager/c_diag_manager.h
@@ -64,17 +64,17 @@ extern int cFMS_register_diag_field_array_cdouble(char *module_name, char *field
                                                   char *interp_method, int *tile_count, int *area, int *volume,
                                                   char *realm, bool *multiple_send_data);                                                 
 
-extern bool cFMS_diag_send_data_2d_cint(int *diag_field_id, int *field_shape, int *field, char *err_msg);
-extern bool cFMS_diag_send_data_3d_cint(int *diag_field_id, int *field_shape, int *field, char *err_msg);
-extern bool cFMS_diag_send_data_4d_cint(int *diag_field_id, int *field_shape, int *field, char *err_msg);
-extern bool cFMS_diag_send_data_5d_cint(int *diag_field_id, int *field_shape, int *field, char *err_msg);
-extern bool cFMS_diag_send_data_2d_cfloat(int *diag_field_id, int *field_shape, float *field, char *err_msg);
-extern bool cFMS_diag_send_data_3d_cfloat(int *diag_field_id, int *field_shape, float *field, char *err_msg);
-extern bool cFMS_diag_send_data_4d_cfloat(int *diag_field_id, int *field_shape, float *field, char *err_msg);
-extern bool cFMS_diag_send_data_5d_cfloat(int *diag_field_id, int *field_shape, float *field, char *err_msg);
-extern bool cFMS_diag_send_data_2d_cdouble(int *diag_field_id, int *field_shape, double *field, char *err_msg);
-extern bool cFMS_diag_send_data_3d_cdouble(int *diag_field_id, int *field_shape, double *field, char *err_msg);
-extern bool cFMS_diag_send_data_4d_cdouble(int *diag_field_id, int *field_shape, double *field, char *err_msg);
-extern bool cFMS_diag_send_data_5d_cdouble(int *diag_field_id, int *field_shape, double *field, char *err_msg);
+extern bool cFMS_diag_send_data_2d_cint(int *diag_field_id, int *field_shape, int *field, char *err_msg, bool *convert_cf_data);
+extern bool cFMS_diag_send_data_3d_cint(int *diag_field_id, int *field_shape, int *field, char *err_msg, bool *convert_cf_data);
+extern bool cFMS_diag_send_data_4d_cint(int *diag_field_id, int *field_shape, int *field, char *err_msg, bool *convert_cf_data);
+extern bool cFMS_diag_send_data_5d_cint(int *diag_field_id, int *field_shape, int *field, char *err_msg, bool *convert_cf_data);
+extern bool cFMS_diag_send_data_2d_cfloat(int *diag_field_id, int *field_shape, float *field, char *err_msg, bool *convert_cf_data);
+extern bool cFMS_diag_send_data_3d_cfloat(int *diag_field_id, int *field_shape, float *field, char *err_msg, bool *convert_cf_data);
+extern bool cFMS_diag_send_data_4d_cfloat(int *diag_field_id, int *field_shape, float *field, char *err_msg, bool *convert_cf_data);
+extern bool cFMS_diag_send_data_5d_cfloat(int *diag_field_id, int *field_shape, float *field, char *err_msg, bool *convert_cf_data);
+extern bool cFMS_diag_send_data_2d_cdouble(int *diag_field_id, int *field_shape, double *field, char *err_msg, bool *convert_cf_data);
+extern bool cFMS_diag_send_data_3d_cdouble(int *diag_field_id, int *field_shape, double *field, char *err_msg, bool *convert_cf_data);
+extern bool cFMS_diag_send_data_4d_cdouble(int *diag_field_id, int *field_shape, double *field, char *err_msg, bool *convert_cf_data);
+extern bool cFMS_diag_send_data_5d_cdouble(int *diag_field_id, int *field_shape, double *field, char *err_msg, bool *convert_cf_data);
 
 #endif

--- a/c_diag_manager/include/c_send_data.inc
+++ b/c_diag_manager/include/c_send_data.inc
@@ -1,4 +1,5 @@
-function CFMS_DIAG_SEND_DATA_(diag_field_id, field_shape, field_ptr, err_msg) bind(C, name=CFMS_DIAG_SEND_DATA_BINDC_)
+function CFMS_DIAG_SEND_DATA_(diag_field_id, field_shape, field_ptr, err_msg, &
+     convert_cf_order) bind(C, name=CFMS_DIAG_SEND_DATA_BINDC_)
   
   implicit none
   
@@ -6,6 +7,7 @@ function CFMS_DIAG_SEND_DATA_(diag_field_id, field_shape, field_ptr, err_msg) bi
   integer, intent(in) :: field_shape(CFMS_DIAG_SEND_DATA_FIELD_NDIM_)
   type(c_ptr), value, intent(in) :: field_ptr
   character(c_bool), intent(out), optional :: err_msg(MESSAGE_LENGTH)
+  logical(c_bool), intent(in), optional :: convert_cf_order
   
   character(MESSAGE_LENGTH-1) :: err_msg_f
   logical(c_bool) :: CFMS_DIAG_SEND_DATA_  
@@ -13,7 +15,7 @@ function CFMS_DIAG_SEND_DATA_(diag_field_id, field_shape, field_ptr, err_msg) bi
   CFMS_DIAG_SEND_DATA_FIELD_TYPE_, allocatable :: field(CFMS_DIAG_SEND_DATA_FIELD_ASSUMED_SHAPE_)
   
   allocate(field(CFMS_DIAG_SEND_DATA_FIELD_SHAPE_))
-  call cFMS_pointer_to_array(field_ptr, field_shape, field)  
+  call cFMS_pointer_to_array(field_ptr, field_shape, field, convert_cf_order)
   
   CFMS_DIAG_SEND_DATA_ = fms_diag_send_data(diag_field_id = diag_field_id, &
                                        field = field,                      &

--- a/c_fms/c_fms.h
+++ b/c_fms/c_fms.h
@@ -112,91 +112,91 @@ extern void cFMS_set_global_domain(int *domain_id, int *xbegin, int *xend, int *
 
 extern void cFMS_update_domains_double_2d(int *field_shape, double *field, int *domain_id, int *flags, int *complete,
                                          int *position, int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                         char *name, int *tile_count);
+                                          char *name, int *tile_count, bool *convert_cf_order);
 
 extern void cFMS_update_domains_double_3d(int *field_shape, double *field, int *domain_id, int *flags, int *complete,
                                          int *position, int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                         char *name, int *tile_count);
+                                          char *name, int *tile_count, bool *convert_cf_order);
 
 extern void cFMS_update_domains_double_4d(int *field_shape, double *field, int *domain_id, int *flags, int *complete,
                                          int *position, int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                         char *name, int *tile_count);
+                                          char *name, int *tile_count, bool *convert_cf_order);
 
 extern void cFMS_update_domains_double_5d(int *field_shape, double *field, int *domain_id, int *flags, int *complete,
                                          int *position, int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                         char *name, int *tile_count);
+                                          char *name, int *tile_count, bool *convert_cf_order);
 
 extern void cFMS_update_domains_float_2d(int *field_shape, float *field, int *domain_id, int *flags, int *complete,
                                          int *position, int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                         char *name, int *tile_count);
+                                         char *name, int *tile_count, bool *convert_cf_order);
 
 extern void cFMS_update_domains_float_3d(int *field_shape, float *field, int *domain_id, int *flags, int *complete,
                                          int *position, int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                         char *name, int *tile_count);
+                                         char *name, int *tile_count, bool *convert_cf_order);
 
 extern void cFMS_update_domains_float_4d(int *field_shape, float *field, int *domain_id, int *flags, int *complete,
                                          int *position, int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                         char *name, int *tile_count);
+                                         char *name, int *tile_count, bool *convert_cf_order);
 
 extern void cFMS_update_domains_float_5d(int *field_shape, float *field, int *domain_id, int *flags, int *complete,
                                          int *position, int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                         char *name, int *tile_count);
+                                         char *name, int *tile_count, bool *convert_cf_order);
 
 extern void cFMS_update_domains_int_2d(int *field_shape, int *field, int *domain_id, int *flags, int *complete,
                                          int *position, int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                         char *name, int *tile_count);
+                                       char *name, int *tile_count, bool *convert_cf_order);
 
 extern void cFMS_update_domains_int_3d(int *field_shape, int *field, int *domain_id, int *flags, int *complete,
                                          int *position, int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                         char *name, int *tile_count);
+                                       char *name, int *tile_count, bool *convert_cf_order);
 
 extern void cFMS_update_domains_int_4d(int *field_shape, int *field, int *domain_id, int *flags, int *complete,
                                          int *position, int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                         char *name, int *tile_count);
+                                       char *name, int *tile_count, bool *convert_cf_order);
 
 extern void cFMS_update_domains_int_5d(int *field_shape, int *field, int *domain_id, int *flags, int *complete,
-                                         int *position, int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                         char *name, int *tile_count);
+                                       int *position, int *whalo, int *ehalo, int *shalo, int *nhalo,
+                                       char *name, int *tile_count, bool *convert_cf_order);
 
 extern void cFMS_v_update_domains_double_2d(int *fieldx_shape, double *fieldx, int *fieldy_shape, double *fieldy,
                                               int *domain_id, int *flags, int *gridtype, int *complete,
                                               int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                              char *name, int *tile_count);
+                                            char *name, int *tile_count, bool *convert_cf_order);
 
 extern void cFMS_v_update_domains_double_3d(int *fieldx_shape, double *fieldx, int *fieldy_shape, double *fieldy,
                                               int *domain_id, int *flags, int *gridtype, int *complete,
                                               int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                              char *name, int *tile_count);
+                                            char *name, int *tile_count, bool *convert_cf_order);
 
 extern void cFMS_v_update_domains_double_4d(int *fieldx_shape, double *fieldx, int *fieldy_shape, double *fieldy,
                                               int *domain_id, int *flags, int *gridtype, int *complete,
                                               int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                              char *name, int *tile_count);
+                                            char *name, int *tile_count, bool *convert_cf_order);
 
 extern void cFMS_v_update_domains_double_5d(int *fieldx_shape, double *fieldx, int *fieldy_shape, double *fieldy,
                                               int *domain_id, int *flags, int *gridtype, int *complete,
                                               int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                              char *name, int *tile_count);
+                                            char *name, int *tile_count, bool *convert_cf_order);
 
 extern void cFMS_v_update_domains_float_2d(int *fieldx_shape, float *fieldx, int *fieldy_shape, float *fieldy,
                                               int *domain_id, int *flags, int *gridtype, int *complete,
                                               int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                              char *name, int *tile_count);
+                                           char *name, int *tile_count, bool *convert_cf_order);
 
 extern void cFMS_v_update_domains_float_3d(int *fieldx_shape, float *fieldx, int *fieldy_shape, float *fieldy,
                                               int *domain_id, int *flags, int *gridtype, int *complete,
                                               int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                              char *name, int *tile_count);
+                                           char *name, int *tile_count, bool *convert_cf_order);
 
 extern void cFMS_v_update_domains_float_4d(int *fieldx_shape, float *fieldx, int *fieldy_shape, float *fieldy,
                                               int *domain_id, int *flags, int *gridtype, int *complete,
                                               int *position, int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                              char *name, int *tile_count);
+                                           char *name, int *tile_count, bool *convert_cf_order);
 
 extern void cFMS_v_update_domains_float_5d(int *fieldx_shape, float *fieldx, int **fieldy_shape, float *fieldy,
                                               int *domain_id, int *flags, int *gridtype, int *complete,
                                               int *whalo, int *ehalo, int *shalo, int *nhalo,
-                                              char *name, int *tile_count);
+                                           char *name, int *tile_count, bool *convert_cf_order);
 
 extern int cFMS_define_cubic_mosaic(int *ni, int *nj, int *global_indices, int *layout, int *ntiles,
                                               int *halo, bool *use_memsize);

--- a/c_fms/include/c_update_domains.inc
+++ b/c_fms/include/c_update_domains.inc
@@ -1,5 +1,5 @@
 subroutine CFMS_UPDATE_DOMAINS_SUB_NAME_(field_shape, field, domain_id, flags, complete, position, &
-     whalo, ehalo, shalo, nhalo, name_c, tile_count) bind(C, name=CFMS_UPDATE_DOMAINS_BINDC_)
+     whalo, ehalo, shalo, nhalo, name_c, tile_count, convert_cf_order) bind(C, name=CFMS_UPDATE_DOMAINS_BINDC_)
 
   implicit none
   integer, intent(in) :: field_shape(CFMS_UPDATE_DOMAINS_FIELD_NDIM_)
@@ -11,6 +11,7 @@ subroutine CFMS_UPDATE_DOMAINS_SUB_NAME_(field_shape, field, domain_id, flags, c
   integer, intent(in), optional :: whalo, ehalo, shalo, nhalo
   character(c_char), intent(in), optional :: name_c(NAME_LENGTH)
   integer, intent(inout), optional :: tile_count
+  logical(c_bool), intent(in), optional :: convert_cf_order
 
   CFMS_UPDATE_DOMAINS_FIELD_TYPE_, allocatable :: field_f(CFMS_UPDATE_DOMAINS_FIELD_POINTER_)
   character(len=NAME_LENGTH) :: name_f
@@ -19,13 +20,13 @@ subroutine CFMS_UPDATE_DOMAINS_SUB_NAME_(field_shape, field, domain_id, flags, c
   if(present(tile_count)) tile_count = tile_count + 1
   
   allocate(field_f(CFMS_UPDATE_DOMAINS_SHAPE_F_))
-  call cFMS_pointer_to_array(field, field_shape, field_f)
+  call cFMS_pointer_to_array(field, field_shape, field_f, convert_cf_order)
   
   call cFMS_set_current_domain(domain_id)  
   call fms_mpp_domains_update_domains(field=field_f, domain=current_domain, flags=flags, complete=complete, &
        position=position, whalo=whalo, ehalo=ehalo, shalo=shalo, nhalo=nhalo, name=name_f, tile_count=tile_count)
 
-  call cFMS_array_to_pointer(field_f, field_shape, field)
+  call cFMS_array_to_pointer(field_f, field_shape, field, convert_cf_order)
   
   deallocate(field_f)
 

--- a/c_fms/include/c_vector_update_domains.inc
+++ b/c_fms/include/c_vector_update_domains.inc
@@ -1,5 +1,5 @@
 subroutine CFMS_V_UPDATE_DOMAINS_SUB_NAME_(fieldx_shape, fieldx, fieldy_shape, fieldy, domain_id, flags, gridtype, &
-  complete, whalo, ehalo, shalo, nhalo, name_c, tile_count) bind(C, name=CFMS_V_UPDATE_DOMAINS_BINDC_)
+  complete, whalo, ehalo, shalo, nhalo, name_c, tile_count, convert_cf_order) bind(C, name=CFMS_V_UPDATE_DOMAINS_BINDC_)
 
   implicit none
   integer, intent(in) :: fieldx_shape(CFMS_V_UPDATE_DOMAINS_FIELD_NDIM_)
@@ -13,6 +13,7 @@ subroutine CFMS_V_UPDATE_DOMAINS_SUB_NAME_(fieldx_shape, fieldx, fieldy_shape, f
   integer, intent(in), optional :: whalo, ehalo, shalo, nhalo
   character(c_char), intent(in), optional :: name_c(NAME_LENGTH)
   integer, intent(inout), optional :: tile_count
+  logical(c_bool), intent(in), optional :: convert_cf_order
 
   CFMS_V_UPDATE_DOMAINS_FIELD_TYPE_, allocatable :: fieldx_f(CFMS_V_UPDATE_DOMAINS_FIELD_POINTER_)
   CFMS_V_UPDATE_DOMAINS_FIELD_TYPE_, allocatable :: fieldy_f(CFMS_V_UPDATE_DOMAINS_FIELD_POINTER_)
@@ -22,18 +23,18 @@ subroutine CFMS_V_UPDATE_DOMAINS_SUB_NAME_(fieldx_shape, fieldx, fieldy_shape, f
   if(present(tile_count)) tile_count = tile_count + 1
   
   allocate(fieldx_f(CFMS_V_UPDATE_DOMAINS_SHAPEX_F_))
-  call cFMS_pointer_to_array(fieldx, fieldx_shape, fieldx_f)
+  call cFMS_pointer_to_array(fieldx, fieldx_shape, fieldx_f, convert_cf_order)
 
   allocate(fieldy_f(CFMS_V_UPDATE_DOMAINS_SHAPEY_F_))
-  call cFMS_pointer_to_array(fieldy, fieldy_shape, fieldy_f)
+  call cFMS_pointer_to_array(fieldy, fieldy_shape, fieldy_f, convert_cf_order)
   
   call cFMS_set_current_domain(domain_id)  
   call fms_mpp_domains_update_domains(fieldx=fieldx_f, fieldy=fieldy_f, domain=current_domain, flags=flags, &
     gridtype=gridtype, complete=complete, whalo=whalo, ehalo=ehalo, shalo=shalo, nhalo=nhalo, name=name_f, &
     tile_count=tile_count)
 
-  call cFMS_array_to_pointer(fieldx_f, fieldx_shape, fieldx)
-  call cFMS_array_to_pointer(fieldy_f, fieldy_shape, fieldy)
+  call cFMS_array_to_pointer(fieldx_f, fieldx_shape, fieldx, convert_cf_order)
+  call cFMS_array_to_pointer(fieldy_f, fieldy_shape, fieldy, convert_cf_order)
   
   deallocate(fieldx_f)
   deallocate(fieldy_f)

--- a/c_fms_utils/include/array_to_pointer.fh
+++ b/c_fms_utils/include/array_to_pointer.fh
@@ -2,48 +2,48 @@
 #undef  CFMS_ARRAY_TO_POINTER_
 #undef  CFMS_ARRAY_TO_POINTER_TYPE_
 #undef  CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_
-#undef  CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_
+#undef  CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_
 #undef  CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_
 #define CFMS_ARRAY_TO_POINTER_                cFMS_array_to_pointer_2d_int
 #define CFMS_ARRAY_TO_POINTER_TYPE_           integer
 #define CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_  :,:
-#define CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_ c_shape(2),c_shape(1)
+#define CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_ f_shape(2),f_shape(1)
 #define CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_   2,1
 #include "array_to_pointer.inc"
 
 #undef  CFMS_ARRAY_TO_POINTER_
 #undef  CFMS_ARRAY_TO_POINTER_TYPE_
 #undef  CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_
-#undef  CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_
+#undef  CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_
 #undef  CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_
 #define CFMS_ARRAY_TO_POINTER_                cFMS_array_to_pointer_3d_int
 #define CFMS_ARRAY_TO_POINTER_TYPE_           integer
 #define CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_  :,:,:
-#define CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_ c_shape(3),c_shape(2),c_shape(1)
+#define CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_ f_shape(3),f_shape(2),f_shape(1)
 #define CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_   3,2,1
 #include "array_to_pointer.inc"
 
 #undef  CFMS_ARRAY_TO_POINTER_
 #undef  CFMS_ARRAY_TO_POINTER_TYPE_
 #undef  CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_
-#undef  CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_
+#undef  CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_
 #undef  CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_
 #define CFMS_ARRAY_TO_POINTER_                cFMS_array_to_pointer_4d_int
 #define CFMS_ARRAY_TO_POINTER_TYPE_           integer
 #define CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_  :,:,:,:
-#define CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_ c_shape(4),c_shape(3),c_shape(2),c_shape(1)
+#define CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_ f_shape(4),f_shape(3),f_shape(2),f_shape(1)
 #define CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_   4,3,2,1
 #include "array_to_pointer.inc"
 
 #undef  CFMS_ARRAY_TO_POINTER_
 #undef  CFMS_ARRAY_TO_POINTER_TYPE_
 #undef  CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_
-#undef  CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_
+#undef  CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_
 #undef  CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_
 #define CFMS_ARRAY_TO_POINTER_                cFMS_array_to_pointer_5d_int
 #define CFMS_ARRAY_TO_POINTER_TYPE_           integer
 #define CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_  :,:,:,:,:
-#define CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_ c_shape(5),c_shape(4),c_shape(3),c_shape(2),c_shape(1)
+#define CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_ f_shape(5),f_shape(4),f_shape(3),f_shape(2),f_shape(1)
 #define CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_   5,4,3,2,1
 #include "array_to_pointer.inc"
 
@@ -51,48 +51,48 @@
 #undef  CFMS_ARRAY_TO_POINTER_
 #undef  CFMS_ARRAY_TO_POINTER_TYPE_
 #undef  CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_
-#undef  CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_
+#undef  CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_
 #undef  CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_
 #define CFMS_ARRAY_TO_POINTER_                cFMS_array_to_pointer_2d_cfloat
 #define CFMS_ARRAY_TO_POINTER_TYPE_           real(c_float)
 #define CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_  :,:
-#define CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_ c_shape(2),c_shape(1)
+#define CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_ f_shape(2),f_shape(1)
 #define CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_   2,1
 #include "array_to_pointer.inc"
 
 #undef  CFMS_ARRAY_TO_POINTER_
 #undef  CFMS_ARRAY_TO_POINTER_TYPE_
 #undef  CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_
-#undef  CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_
+#undef  CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_
 #undef  CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_
 #define CFMS_ARRAY_TO_POINTER_                cFMS_array_to_pointer_3d_cfloat
 #define CFMS_ARRAY_TO_POINTER_TYPE_           real(c_float)
 #define CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_  :,:,:
-#define CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_ c_shape(3),c_shape(2),c_shape(1)
+#define CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_ f_shape(3),f_shape(2),f_shape(1)
 #define CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_   3,2,1
 #include "array_to_pointer.inc"
 
 #undef  CFMS_ARRAY_TO_POINTER_
 #undef  CFMS_ARRAY_TO_POINTER_TYPE_
 #undef  CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_
-#undef  CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_
+#undef  CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_
 #undef  CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_
 #define CFMS_ARRAY_TO_POINTER_                cFMS_array_to_pointer_4d_cfloat
 #define CFMS_ARRAY_TO_POINTER_TYPE_           real(c_float)
 #define CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_  :,:,:,:
-#define CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_ c_shape(4),c_shape(3),c_shape(2),c_shape(1)
+#define CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_ f_shape(4),f_shape(3),f_shape(2),f_shape(1)
 #define CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_   4,3,2,1
 #include "array_to_pointer.inc"
 
 #undef  CFMS_ARRAY_TO_POINTER_
 #undef  CFMS_ARRAY_TO_POINTER_TYPE_
 #undef  CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_
-#undef  CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_
+#undef  CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_
 #undef  CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_
 #define CFMS_ARRAY_TO_POINTER_                cFMS_array_to_pointer_5d_cfloat
 #define CFMS_ARRAY_TO_POINTER_TYPE_           real(c_float)
 #define CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_  :,:,:,:,:
-#define CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_ c_shape(5),c_shape(4),c_shape(3),c_shape(2),c_shape(1)
+#define CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_ f_shape(5),f_shape(4),f_shape(3),f_shape(2),f_shape(1)
 #define CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_   5,4,3,2,1
 #include "array_to_pointer.inc"
 
@@ -100,48 +100,48 @@
 #undef  CFMS_ARRAY_TO_POINTER_
 #undef  CFMS_ARRAY_TO_POINTER_TYPE_
 #undef  CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_
-#undef  CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_
+#undef  CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_
 #undef  CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_
 #define CFMS_ARRAY_TO_POINTER_                cFMS_array_to_pointer_2d_cdouble
 #define CFMS_ARRAY_TO_POINTER_TYPE_           real(c_double)
 #define CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_  :,:
-#define CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_ c_shape(2),c_shape(1)
+#define CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_ f_shape(2),f_shape(1)
 #define CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_   2,1
 #include "array_to_pointer.inc"
 
 #undef  CFMS_ARRAY_TO_POINTER_
 #undef  CFMS_ARRAY_TO_POINTER_TYPE_
 #undef  CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_
-#undef  CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_
+#undef  CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_
 #undef  CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_
 #define CFMS_ARRAY_TO_POINTER_                cFMS_array_to_pointer_3d_cdouble
 #define CFMS_ARRAY_TO_POINTER_TYPE_           real(c_double)
 #define CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_  :,:,:
-#define CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_ c_shape(3),c_shape(2),c_shape(1)
+#define CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_ f_shape(3),f_shape(2),f_shape(1)
 #define CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_   3,2,1
 #include "array_to_pointer.inc"
 
 #undef  CFMS_ARRAY_TO_POINTER_
 #undef  CFMS_ARRAY_TO_POINTER_TYPE_
 #undef  CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_
-#undef  CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_
+#undef  CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_
 #undef  CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_
 #define CFMS_ARRAY_TO_POINTER_                cFMS_array_to_pointer_4d_cdouble
 #define CFMS_ARRAY_TO_POINTER_TYPE_           real(c_double)
 #define CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_  :,:,:,:
-#define CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_ c_shape(4),c_shape(3),c_shape(2),c_shape(1)
+#define CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_ f_shape(4),f_shape(3),f_shape(2),f_shape(1)
 #define CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_   4,3,2,1
 #include "array_to_pointer.inc"
 
 #undef  CFMS_ARRAY_TO_POINTER_
 #undef  CFMS_ARRAY_TO_POINTER_TYPE_
 #undef  CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_
-#undef  CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_
+#undef  CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_
 #undef  CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_
 #define CFMS_ARRAY_TO_POINTER_                cFMS_array_to_pointer_5d_cdouble
 #define CFMS_ARRAY_TO_POINTER_TYPE_           real(c_double)
 #define CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_  :,:,:,:,:
-#define CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_ c_shape(5),c_shape(4),c_shape(3),c_shape(2),c_shape(1)
+#define CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_ f_shape(5),f_shape(4),f_shape(3),f_shape(2),f_shape(1)
 #define CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_   5,4,3,2,1
 #include "array_to_pointer.inc"
 
@@ -149,47 +149,47 @@
 #undef  CFMS_ARRAY_TO_POINTER_
 #undef  CFMS_ARRAY_TO_POINTER_TYPE_
 #undef  CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_
-#undef  CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_
+#undef  CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_
 #undef  CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_
 #define CFMS_ARRAY_TO_POINTER_                cFMS_array_to_pointer_2d_logical
 #define CFMS_ARRAY_TO_POINTER_TYPE_           logical
 #define CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_  :,:
-#define CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_ c_shape(2),c_shape(1)
+#define CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_ f_shape(2),f_shape(1)
 #define CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_   2,1
 #include "array_to_pointer.inc"
 
 #undef  CFMS_ARRAY_TO_POINTER_
 #undef  CFMS_ARRAY_TO_POINTER_TYPE_
 #undef  CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_
-#undef  CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_
+#undef  CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_
 #undef  CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_
 #define CFMS_ARRAY_TO_POINTER_                cFMS_array_to_pointer_3d_logical
 #define CFMS_ARRAY_TO_POINTER_TYPE_           logical
 #define CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_  :,:,:
-#define CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_ c_shape(3),c_shape(2),c_shape(1)
+#define CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_ f_shape(3),f_shape(2),f_shape(1)
 #define CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_   3,2,1
 #include "array_to_pointer.inc"
 
 #undef  CFMS_ARRAY_TO_POINTER_
 #undef  CFMS_ARRAY_TO_POINTER_TYPE_
 #undef  CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_
-#undef  CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_
+#undef  CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_
 #undef  CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_
 #define CFMS_ARRAY_TO_POINTER_                cFMS_array_to_pointer_4d_logical
 #define CFMS_ARRAY_TO_POINTER_TYPE_           logical
 #define CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_  :,:,:,:
-#define CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_ c_shape(4),c_shape(3),c_shape(2),c_shape(1)
+#define CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_ f_shape(4),f_shape(3),f_shape(2),f_shape(1)
 #define CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_   4,3,2,1
 #include "array_to_pointer.inc"
 
 #undef  CFMS_ARRAY_TO_POINTER_
 #undef  CFMS_ARRAY_TO_POINTER_TYPE_
 #undef  CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_
-#undef  CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_
+#undef  CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_
 #undef  CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_
 #define CFMS_ARRAY_TO_POINTER_                cFMS_array_to_pointer_5d_logical
 #define CFMS_ARRAY_TO_POINTER_TYPE_           logical
 #define CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_  :,:,:,:,:
-#define CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_ c_shape(5),c_shape(4),c_shape(3),c_shape(2),c_shape(1)
+#define CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_ f_shape(5),f_shape(4),f_shape(3),f_shape(2),f_shape(1)
 #define CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_   5,4,3,2,1
 #include "array_to_pointer.inc"

--- a/c_fms_utils/include/array_to_pointer.inc
+++ b/c_fms_utils/include/array_to_pointer.inc
@@ -1,20 +1,28 @@
-subroutine CFMS_ARRAY_TO_POINTER_(f_array, c_shape, c_pointer)
+subroutine CFMS_ARRAY_TO_POINTER_(f_array, f_shape, c_pointer, convert_f_to_c_order)
 
   implicit none
-  integer, intent(in) :: c_shape(:)
+  integer, intent(in) :: f_shape(:)
   CFMS_ARRAY_TO_POINTER_TYPE_, intent(in) :: f_array(CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_)
   type(c_ptr), value, intent(in) :: c_pointer
+  logical(c_bool), intent(in), optional :: convert_f_to_c_order
 
+  logical :: convert_f_to_c_order_ = .true.  
   CFMS_ARRAY_TO_POINTER_TYPE_, pointer :: cf_pointer(CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_)
   CFMS_ARRAY_TO_POINTER_TYPE_, allocatable :: tmp_array(CFMS_ARRAY_TO_POINTER_ASSUMED_SHAPE_)
-  
-  allocate(tmp_array(CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_))
-  tmp_array = reshape(f_array, [CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_], order=[CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_])
 
-  call c_f_pointer(c_pointer, cf_pointer, [CFMS_ARRAY_TO_POINTER_REVERSED_SHAPE_])
-  cf_pointer = tmp_array
+  if(present(convert_f_to_c_order)) convert_f_to_c_order_ = logical(convert_f_to_c_order)
   
-  deallocate(tmp_array)
+  if(convert_f_to_c_order_) then
+     allocate(tmp_array(CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_))
+     tmp_array = reshape(f_array, [CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_], order=[CFMS_ARRAY_TO_POINTER_COLUMN_MAJOR_])
+     call c_f_pointer(c_pointer, cf_pointer, [CFMS_ARRAY_TO_POINTER_REVERSED_F_SHAPE_])
+     cf_pointer = tmp_array
+     deallocate(tmp_array)
+  else
+     call c_f_pointer(c_pointer, cf_pointer, f_shape)
+     cf_pointer = f_array
+  end if
+  
   nullify(cf_pointer)
   
 end subroutine CFMS_ARRAY_TO_POINTER_

--- a/c_fms_utils/include/pointer_to_array.fh
+++ b/c_fms_utils/include/pointer_to_array.fh
@@ -1,15 +1,15 @@
-!integer 
+  !integer 
 #undef  CFMS_POINTER_TO_ARRAY_
 #undef  CFMS_POINTER_TO_ARRAY_TYPE_
 #undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_SHAPE_
-#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
 #define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_2d_int
 #define CFMS_POINTER_TO_ARRAY_TYPE_           integer
 #define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:
-#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2)/)
-#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/f_shape(1), f_shape(2)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_ (/f_shape(2),f_shape(1)/)
 #define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/2,1/)
 #include "pointer_to_array.inc"
 
@@ -17,13 +17,13 @@
 #undef  CFMS_POINTER_TO_ARRAY_TYPE_
 #undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_SHAPE_
-#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
 #define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_3d_int
 #define CFMS_POINTER_TO_ARRAY_TYPE_           integer
 #define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:,:
-#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2), c_shape(3)/)
-#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(3),c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/f_shape(1), f_shape(2), f_shape(3)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_ (/f_shape(3),f_shape(2),f_shape(1)/)
 #define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/3,2,1/)
 #include "pointer_to_array.inc"
 
@@ -31,13 +31,13 @@
 #undef  CFMS_POINTER_TO_ARRAY_TYPE_
 #undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_SHAPE_
-#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
 #define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_4d_int
 #define CFMS_POINTER_TO_ARRAY_TYPE_           integer
 #define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:,:,:
-#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2), c_shape(3), c_shape(4)/)
-#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(4),c_shape(3),c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/f_shape(1), f_shape(2), f_shape(3), f_shape(4)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_ (/f_shape(4),f_shape(3),f_shape(2),f_shape(1)/)
 #define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/4,3,2,1/)
 #include "pointer_to_array.inc"
 
@@ -45,13 +45,13 @@
 #undef  CFMS_POINTER_TO_ARRAY_TYPE_
 #undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_SHAPE_
-#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
 #define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_5d_int
 #define CFMS_POINTER_TO_ARRAY_TYPE_           integer
 #define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:,:,:,:
-#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2), c_shape(3), c_shape(4), c_shape(5)/)
-#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(5),c_shape(4),c_shape(3),c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/f_shape(1), f_shape(2), f_shape(3), f_shape(4), f_shape(5)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_ (/f_shape(5),f_shape(4),f_shape(3),f_shape(2),f_shape(1)/)
 #define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/5,4,3,2,1/)
 #include "pointer_to_array.inc"
 
@@ -61,13 +61,13 @@
 #undef  CFMS_POINTER_TO_ARRAY_TYPE_
 #undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_SHAPE_
-#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
 #define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_2d_cfloat
 #define CFMS_POINTER_TO_ARRAY_TYPE_           real(c_float)
 #define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:
-#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2)/)
-#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/f_shape(1), f_shape(2)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_ (/f_shape(2),f_shape(1)/)
 #define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/2,1/)
 #include "pointer_to_array.inc"
 
@@ -75,13 +75,13 @@
 #undef  CFMS_POINTER_TO_ARRAY_TYPE_
 #undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_SHAPE_
-#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
 #define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_3d_cfloat
 #define CFMS_POINTER_TO_ARRAY_TYPE_           real(c_float)
 #define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:,:
-#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2), c_shape(3)/)
-#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(3),c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/f_shape(1), f_shape(2), f_shape(3)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_ (/f_shape(3),f_shape(2),f_shape(1)/)
 #define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/3,2,1/)
 #include "pointer_to_array.inc"
 
@@ -89,13 +89,13 @@
 #undef  CFMS_POINTER_TO_ARRAY_TYPE_
 #undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_SHAPE_
-#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
 #define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_4d_cfloat
 #define CFMS_POINTER_TO_ARRAY_TYPE_           real(c_float)
 #define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:,:,:
-#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2), c_shape(3), c_shape(4)/)
-#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(4),c_shape(3),c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/f_shape(1), f_shape(2), f_shape(3), f_shape(4)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_ (/f_shape(4),f_shape(3),f_shape(2),f_shape(1)/)
 #define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/4,3,2,1/)
 #include "pointer_to_array.inc"
 
@@ -103,13 +103,13 @@
 #undef  CFMS_POINTER_TO_ARRAY_TYPE_
 #undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_SHAPE_
-#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
 #define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_5d_cfloat
 #define CFMS_POINTER_TO_ARRAY_TYPE_           real(c_float)
 #define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:,:,:,:
-#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2), c_shape(3), c_shape(4), c_shape(5)/)
-#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(5),c_shape(4),c_shape(3),c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/f_shape(1), f_shape(2), f_shape(3), f_shape(4), f_shape(5)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_ (/f_shape(5),f_shape(4),f_shape(3),f_shape(2),f_shape(1)/)
 #define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/5,4,3,2,1/)
 #include "pointer_to_array.inc"
 
@@ -118,13 +118,13 @@
 #undef  CFMS_POINTER_TO_ARRAY_TYPE_
 #undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_SHAPE_
-#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
 #define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_2d_cdouble
 #define CFMS_POINTER_TO_ARRAY_TYPE_           real(c_double)
 #define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:
-#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2)/)
-#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/f_shape(1), f_shape(2)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_ (/f_shape(2),f_shape(1)/)
 #define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/2,1/)
 #include "pointer_to_array.inc"
 
@@ -132,13 +132,13 @@
 #undef  CFMS_POINTER_TO_ARRAY_TYPE_
 #undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_SHAPE_
-#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
 #define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_3d_cdouble
 #define CFMS_POINTER_TO_ARRAY_TYPE_           real(c_double)
 #define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:,:
-#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2), c_shape(3)/)
-#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(3),c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/f_shape(1), f_shape(2), f_shape(3)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_ (/f_shape(3),f_shape(2),f_shape(1)/)
 #define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/3,2,1/)
 #include "pointer_to_array.inc"
 
@@ -146,13 +146,13 @@
 #undef  CFMS_POINTER_TO_ARRAY_TYPE_
 #undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_SHAPE_
-#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
 #define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_4d_cdouble
 #define CFMS_POINTER_TO_ARRAY_TYPE_           real(c_double)
 #define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:,:,:
-#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2), c_shape(3), c_shape(4)/)
-#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(4),c_shape(3),c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/f_shape(1), f_shape(2), f_shape(3), f_shape(4)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_ (/f_shape(4),f_shape(3),f_shape(2),f_shape(1)/)
 #define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/4,3,2,1/)
 #include "pointer_to_array.inc"
 
@@ -160,13 +160,13 @@
 #undef  CFMS_POINTER_TO_ARRAY_TYPE_
 #undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_SHAPE_
-#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
 #define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_5d_cdouble
 #define CFMS_POINTER_TO_ARRAY_TYPE_           real(c_double)
 #define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:,:,:,:
-#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2), c_shape(3), c_shape(4), c_shape(5)/)
-#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(5),c_shape(4),c_shape(3),c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/f_shape(1), f_shape(2), f_shape(3), f_shape(4), f_shape(5)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_ (/f_shape(5),f_shape(4),f_shape(3),f_shape(2),f_shape(1)/)
 #define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/5,4,3,2,1/)
 #include "pointer_to_array.inc"
 
@@ -175,13 +175,13 @@
 #undef  CFMS_POINTER_TO_ARRAY_TYPE_
 #undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_SHAPE_
-#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
 #define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_2d_cbool
 #define CFMS_POINTER_TO_ARRAY_TYPE_           logical(c_bool)
 #define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:
-#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2)/)
-#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/f_shape(1), f_shape(2)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_ (/f_shape(2),f_shape(1)/)
 #define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/2,1/)
 #include "pointer_to_array.inc"
 
@@ -189,13 +189,13 @@
 #undef  CFMS_POINTER_TO_ARRAY_TYPE_
 #undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_SHAPE_
-#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
 #define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_3d_cbool
 #define CFMS_POINTER_TO_ARRAY_TYPE_           logical(c_bool)
 #define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:,:
-#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2), c_shape(3)/)
-#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(3),c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/f_shape(1), f_shape(2), f_shape(3)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_ (/f_shape(3),f_shape(2),f_shape(1)/)
 #define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/3,2,1/)
 #include "pointer_to_array.inc"
 
@@ -203,13 +203,13 @@
 #undef  CFMS_POINTER_TO_ARRAY_TYPE_
 #undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_SHAPE_
-#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
 #define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_4d_cbool
 #define CFMS_POINTER_TO_ARRAY_TYPE_           logical(c_bool)
 #define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:,:,:
-#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2), c_shape(3), c_shape(4)/)
-#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(4),c_shape(3),c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/f_shape(1), f_shape(2), f_shape(3), f_shape(4)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_ (/f_shape(4),f_shape(3),f_shape(2),f_shape(1)/)
 #define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/4,3,2,1/)
 #include "pointer_to_array.inc"
 
@@ -217,13 +217,13 @@
 #undef  CFMS_POINTER_TO_ARRAY_TYPE_
 #undef  CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_SHAPE_
-#undef  CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_
+#undef  CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_
 #undef  CFMS_POINTER_TO_ARRAY_ROW_MAJOR_
 #define CFMS_POINTER_TO_ARRAY_                cFMS_pointer_to_array_5d_cbool
 #define CFMS_POINTER_TO_ARRAY_TYPE_           logical(c_bool)
 #define CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_  :,:,:,:,:
-#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/c_shape(1), c_shape(2), c_shape(3), c_shape(4), c_shape(5)/)
-#define CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_ (/c_shape(5),c_shape(4),c_shape(3),c_shape(2),c_shape(1)/)
+#define CFMS_POINTER_TO_ARRAY_SHAPE_ (/f_shape(1), f_shape(2), f_shape(3), f_shape(4), f_shape(5)/)
+#define CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_ (/f_shape(5),f_shape(4),f_shape(3),f_shape(2),f_shape(1)/)
 #define CFMS_POINTER_TO_ARRAY_ROW_MAJOR_      (/5,4,3,2,1/)
 #include "pointer_to_array.inc"
 

--- a/c_fms_utils/include/pointer_to_array.inc
+++ b/c_fms_utils/include/pointer_to_array.inc
@@ -1,14 +1,23 @@
-subroutine CFMS_POINTER_TO_ARRAY_(c_pointer, c_shape, f_array)
+subroutine CFMS_POINTER_TO_ARRAY_(c_pointer, f_shape, f_array, convert_c_to_f_order)
   
   implicit none
   type(c_ptr), intent(in), value :: c_pointer
-  integer, intent(in) :: c_shape(:)
+  integer, intent(in) :: f_shape(:)
   CFMS_POINTER_TO_ARRAY_TYPE_, intent(out) :: f_array(CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_)
+  logical(c_bool), intent(in), optional :: convert_c_to_f_order
 
+  logical :: convert_c_to_f_order_ = .true.
   CFMS_POINTER_TO_ARRAY_TYPE_, pointer :: f_pointer(CFMS_POINTER_TO_ARRAY_ASSUMED_SHAPE_)
+
+  if(present(convert_c_to_f_order)) convert_c_to_f_order_ = logical(convert_c_to_f_order)
   
-  call c_f_pointer(c_pointer, f_pointer, CFMS_POINTER_TO_ARRAY_REVERSED_SHAPE_)
-  f_array = reshape(f_pointer, shape=CFMS_POINTER_TO_ARRAY_SHAPE_, order=CFMS_POINTER_TO_ARRAY_ROW_MAJOR_)
+  if(convert_c_to_f_order_) then
+     call c_f_pointer(c_pointer, f_pointer, CFMS_POINTER_TO_ARRAY_REVERSED_F_SHAPE_)
+     f_array = reshape(f_pointer, shape=CFMS_POINTER_TO_ARRAY_SHAPE_, order=CFMS_POINTER_TO_ARRAY_ROW_MAJOR_)
+  else
+     call c_f_pointer(c_pointer, f_pointer, CFMS_POINTER_TO_ARRAY_SHAPE_)
+     f_array = f_pointer
+  end if
 
   nullify(f_pointer)
 

--- a/c_horiz_interp/c_horiz_interp.h
+++ b/c_horiz_interp/c_horiz_interp.h
@@ -14,26 +14,24 @@ extern void cFMS_horiz_interp_init(int *ninterp);
 
 extern void cFMS_horiz_interp_end();
 
-extern int cFMS_horiz_interp_new_2d_cfloat(float *lon_in_ptr,float *lat_in_ptr, int *lonlat_in_shape, 
-                                           float *lon_out_ptr, float *lat_out_ptr, int *lonlat_out_shape,
-                                           float *mask_in_ptr, float *mask_out_ptr, char *interp_method,
-                                           int *verbose, float *max_dist, bool *src_modulo, 
+extern int cFMS_horiz_interp_new_2d_cfloat(int *nlon_in, int *nlat_in, int *nlon_out, int *nlat_out,
+                                           float *lon_in_ptr,float *lat_in_ptr, float *lon_out_ptr,
+                                           float *lat_out_ptr, float *mask_in_ptr, float *mask_out_ptr,
+                                           char *interp_method, int *verbose, float *max_dist, bool *src_modulo, 
                                            bool *is_latlon_in, bool *is_latlon_out, bool *convert_cf_order);
 
-extern int cFMS_horiz_interp_new_2d_cdouble(double *lon_in_ptr,double *lat_in_ptr, int *lonlat_in_shape, 
-                                            double *lon_out_ptr, double *lat_out_ptr, int *lonlat_out_shape,
-                                            double *mask_in_ptr, double *mask_out_ptr, char *interp_method,
-                                            int *verbose, double *max_dist, bool *src_modulo, 
+extern int cFMS_horiz_interp_new_2d_cdouble(int *nlon_in, int *nlat_in, int *nlon_out, int *nlat_out,
+                                            double *lon_in_ptr,double *lat_in_ptr, double *lon_out_ptr,
+                                            double *lat_out_ptr, double *mask_in_ptr, double *mask_out_ptr,
+                                            char *interp_method, int *verbose, double *max_dist, bool *src_modulo, 
                                             bool *is_latlon_in, bool *is_latlon_out, bool *convert_cf_order);
 
-extern void cFMS_horiz_interp_base_2d_cfloat(int *interp_id, float *data_in_ptr, int *data_in_shape,
-                                             float *data_out_ptr, int *data_out_shape,
+extern void cFMS_horiz_interp_base_2d_cfloat(int *interp_id, float *data_in_ptr, float *data_out_ptr, 
                                              float *mask_in_ptr, float *mask_out_ptr, int *verbose,
                                              float *missing_value, int *missing_permit, bool *new_missing_handle,
                                              bool *convert_cf_order);
 
-extern void cFMS_horiz_interp_base_2d_cdouble(int *interp_id, double *data_in_ptr, int *data_in_shape,
-                                              double *data_out_ptr, int *data_out_shape,
+extern void cFMS_horiz_interp_base_2d_cdouble(int *interp_id, double *data_in_ptr, double *data_out_ptr,
                                               double *mask_in_ptr, double *mask_out_ptr, int *verbose,
                                               double *missing_value, int *missing_permit, bool *new_missing_handle,
                                               bool *convert_cf_order);

--- a/c_horiz_interp/c_horiz_interp.h
+++ b/c_horiz_interp/c_horiz_interp.h
@@ -18,23 +18,25 @@ extern int cFMS_horiz_interp_new_2d_cfloat(float *lon_in_ptr,float *lat_in_ptr, 
                                            float *lon_out_ptr, float *lat_out_ptr, int *lonlat_out_shape,
                                            float *mask_in_ptr, float *mask_out_ptr, char *interp_method,
                                            int *verbose, float *max_dist, bool *src_modulo, 
-                                           bool *is_latlon_in, bool *is_latlon_out);
+                                           bool *is_latlon_in, bool *is_latlon_out, bool *convert_cf_order);
 
 extern int cFMS_horiz_interp_new_2d_cdouble(double *lon_in_ptr,double *lat_in_ptr, int *lonlat_in_shape, 
                                             double *lon_out_ptr, double *lat_out_ptr, int *lonlat_out_shape,
                                             double *mask_in_ptr, double *mask_out_ptr, char *interp_method,
                                             int *verbose, double *max_dist, bool *src_modulo, 
-                                            bool *is_latlon_in, bool *is_latlon_out);
+                                            bool *is_latlon_in, bool *is_latlon_out, bool *convert_cf_order);
 
 extern void cFMS_horiz_interp_base_2d_cfloat(int *interp_id, float *data_in_ptr, int *data_in_shape,
                                              float *data_out_ptr, int *data_out_shape,
                                              float *mask_in_ptr, float *mask_out_ptr, int *verbose,
-                                             float *missing_value, int *missing_permit, bool *new_missing_handle);
+                                             float *missing_value, int *missing_permit, bool *new_missing_handle,
+                                             bool *convert_cf_order);
 
 extern void cFMS_horiz_interp_base_2d_cdouble(int *interp_id, double *data_in_ptr, int *data_in_shape,
                                               double *data_out_ptr, int *data_out_shape,
                                               double *mask_in_ptr, double *mask_out_ptr, int *verbose,
-                                              double *missing_value, int *missing_permit, bool *new_missing_handle);
+                                              double *missing_value, int *missing_permit, bool *new_missing_handle,
+                                              bool *convert_cf_order);
 
 // Integer pointer getters
 extern void cFMS_get_i_src(int *interp_id, int *i_src);

--- a/c_horiz_interp/include/c_horiz_interp_base.inc
+++ b/c_horiz_interp/include/c_horiz_interp_base.inc
@@ -1,13 +1,11 @@
-subroutine CFMS_HORIZ_INTERP_BASE_2D_(interp_id, data_in_ptr, data_in_shape, &
-     data_out_ptr, data_out_shape, mask_in_ptr, mask_out_ptr, verbose, missing_value, &
+subroutine CFMS_HORIZ_INTERP_BASE_2D_(interp_id, data_in_ptr, data_out_ptr, &
+     mask_in_ptr, mask_out_ptr, verbose, missing_value, &
      missing_permit, new_missing_handle, convert_cf_order) bind(C, name=CFMS_HORIZ_INTERP_BASE_2D_BINDC_)
   
   implicit none
   integer, intent(in) :: interp_id
   type(c_ptr), intent(in), value :: data_in_ptr
-  integer, intent(in) :: data_in_shape(2)
   type(c_ptr), intent(in), value :: data_out_ptr
-  integer, intent(in) :: data_out_shape(2)
   type(c_ptr), intent(in), value :: mask_in_ptr
   type(c_ptr), intent(in), value :: mask_out_ptr
   integer, intent(in), optional :: verbose
@@ -19,24 +17,35 @@ subroutine CFMS_HORIZ_INTERP_BASE_2D_(interp_id, data_in_ptr, data_in_shape, &
   logical :: new_missing_handle_f
   logical :: mask_in_present, mask_out_present
 
+  integer :: in_shape(2), out_shape(2)
+  integer :: nlon_in, nlat_in, nlon_out, nlat_out
+  
   CFMS_HORIZ_INTERP_BASE_2D_TYPE_, allocatable :: data_in(:,:)
   CFMS_HORIZ_INTERP_BASE_2D_TYPE_, allocatable :: data_out(:,:)
   CFMS_HORIZ_INTERP_BASE_2D_TYPE_, pointer :: mask_in(:,:)
   CFMS_HORIZ_INTERP_BASE_2D_TYPE_, pointer :: mask_out(:,:)
+
+  nlon_in = interp(interp_id)%nlon_src
+  nlat_in = interp(interp_id)%nlat_src
+  nlon_out = interp(interp_id)%nlon_dst
+  nlat_out = interp(interp_id)%nlat_dst
+
+  in_shape = (/nlon_in, nlat_in/)
+  out_shape = (/nlon_out, nlat_out/)
   
-  allocate(data_in(data_in_shape(1), data_in_shape(2)))
-  allocate(data_out(data_out_shape(1), data_out_shape(2)))
+  allocate(data_in(nlon_in, nlat_in))
+  allocate(data_out(nlon_out, nlat_out))
 
-  call cFMS_pointer_to_array(data_in_ptr, data_in_shape, data_in, convert_cf_order)
-  call cFMS_pointer_to_array(data_out_ptr, data_out_shape, data_out, convert_cf_order)
-
+  call cFMS_pointer_to_array(data_in_ptr, in_shape, data_in, convert_cf_order)
+  call cFMS_pointer_to_array(data_out_ptr, out_shape, data_out, convert_cf_order)
+  
   mask_in_present = c_associated(mask_in_ptr)
   mask_out_present = c_associated(mask_out_ptr)
   if(mask_in_present) then
-     call cFMS_pointer_to_array(mask_in_ptr, data_in_shape, mask_in, convert_cf_order)
+     call cFMS_pointer_to_array(mask_in_ptr, in_shape, mask_in, convert_cf_order)
   end if
   if(mask_out_present) then
-     call cFMS_pointer_to_array(mask_out_ptr, data_out_shape, mask_out, convert_cf_order)
+     call cFMS_pointer_to_array(mask_out_ptr, out_shape, mask_out, convert_cf_order)
   end if
 
   if(present(new_missing_handle)) then
@@ -61,8 +70,6 @@ subroutine CFMS_HORIZ_INTERP_BASE_2D_(interp_id, data_in_ptr, data_in_shape, &
           new_missing_handle=new_missing_handle_f)
   end if
 
-  write(*,*) interp(interp_id)%nxgrid
-  
-  call cFMS_array_to_pointer(data_out, data_out_shape, data_out_ptr, convert_cf_order)
+  call cFMS_array_to_pointer(data_out, out_shape, data_out_ptr, convert_cf_order)
 
 end subroutine CFMS_HORIZ_INTERP_BASE_2D_

--- a/c_horiz_interp/include/c_horiz_interp_base.inc
+++ b/c_horiz_interp/include/c_horiz_interp_base.inc
@@ -1,6 +1,6 @@
 subroutine CFMS_HORIZ_INTERP_BASE_2D_(interp_id, data_in_ptr, data_in_shape, &
      data_out_ptr, data_out_shape, mask_in_ptr, mask_out_ptr, verbose, missing_value, &
-     missing_permit, new_missing_handle) bind(C, name=CFMS_HORIZ_INTERP_BASE_2D_BINDC_)
+     missing_permit, new_missing_handle, convert_cf_order) bind(C, name=CFMS_HORIZ_INTERP_BASE_2D_BINDC_)
   
   implicit none
   integer, intent(in) :: interp_id
@@ -14,6 +14,7 @@ subroutine CFMS_HORIZ_INTERP_BASE_2D_(interp_id, data_in_ptr, data_in_shape, &
   CFMS_HORIZ_INTERP_BASE_2D_TYPE_, intent(in), optional :: missing_value
   integer, intent(in), optional :: missing_permit
   logical(c_bool), intent(in), optional :: new_missing_handle
+  logical(c_bool), intent(in), optional :: convert_cf_order
 
   logical :: new_missing_handle_f
   logical :: mask_in_present, mask_out_present
@@ -26,16 +27,16 @@ subroutine CFMS_HORIZ_INTERP_BASE_2D_(interp_id, data_in_ptr, data_in_shape, &
   allocate(data_in(data_in_shape(1), data_in_shape(2)))
   allocate(data_out(data_out_shape(1), data_out_shape(2)))
 
-  call cFMS_pointer_to_array(data_in_ptr, data_in_shape, data_in)
-  call cFMS_pointer_to_array(data_out_ptr, data_out_shape, data_out)
+  call cFMS_pointer_to_array(data_in_ptr, data_in_shape, data_in, convert_cf_order)
+  call cFMS_pointer_to_array(data_out_ptr, data_out_shape, data_out, convert_cf_order)
 
   mask_in_present = c_associated(mask_in_ptr)
   mask_out_present = c_associated(mask_out_ptr)
   if(mask_in_present) then
-     call cFMS_pointer_to_array(mask_in_ptr, data_in_shape, mask_in)
+     call cFMS_pointer_to_array(mask_in_ptr, data_in_shape, mask_in, convert_cf_order)
   end if
   if(mask_out_present) then
-     call cFMS_pointer_to_array(mask_out_ptr, data_out_shape, mask_out)
+     call cFMS_pointer_to_array(mask_out_ptr, data_out_shape, mask_out, convert_cf_order)
   end if
 
   if(present(new_missing_handle)) then
@@ -62,6 +63,6 @@ subroutine CFMS_HORIZ_INTERP_BASE_2D_(interp_id, data_in_ptr, data_in_shape, &
 
   write(*,*) interp(interp_id)%nxgrid
   
-  call cFMS_array_to_pointer(data_out, data_out_shape, data_out_ptr)
+  call cFMS_array_to_pointer(data_out, data_out_shape, data_out_ptr, convert_cf_order)
 
 end subroutine CFMS_HORIZ_INTERP_BASE_2D_

--- a/c_horiz_interp/include/c_horiz_interp_new.inc
+++ b/c_horiz_interp/include/c_horiz_interp_new.inc
@@ -1,16 +1,15 @@
-function CFMS_HORIZ_INTERP_NEW_2D_(lon_in_ptr, lat_in_ptr, lonlat_in_shape,&
-     lon_out_ptr, lat_out_ptr, lonlat_out_shape, mask_in_ptr, mask_out_ptr, &
+function CFMS_HORIZ_INTERP_NEW_2D_(nlon_in, nlat_in, nlon_out, nlat_out, &
+     lon_in_ptr, lat_in_ptr, lon_out_ptr, lat_out_ptr, mask_in_ptr, mask_out_ptr, &
      interp_method, verbose, max_dist, src_modulo, is_latlon_in, is_latlon_out, convert_cf_order) &
      bind(C, name=CFMS_HORIZ_INTERP_NEW_2D_BINDC_)
 
   implicit none
 
+  integer, intent(in) :: nlon_in, nlat_in, nlon_out, nlat_out
   type(c_ptr), intent(in), value :: lon_in_ptr
   type(c_ptr), intent(in), value :: lat_in_ptr
-  integer, intent(in) :: lonlat_in_shape(2)
   type(c_ptr), intent(in), value :: lon_out_ptr
   type(c_ptr), intent(in), value :: lat_out_ptr
-  integer, intent(in) :: lonlat_out_shape(2)
   type(c_ptr), intent(in), value :: mask_in_ptr
   type(c_ptr), intent(in), value :: mask_out_ptr
   character(c_char), intent(in), optional :: interp_method(MESSAGE_LENGTH)
@@ -22,13 +21,13 @@ function CFMS_HORIZ_INTERP_NEW_2D_(lon_in_ptr, lat_in_ptr, lonlat_in_shape,&
   logical(c_bool), intent(in), optional :: convert_cf_order
 
   integer :: CFMS_HORIZ_INTERP_NEW_2D_
-  integer :: mask_shape(2)
   character(MESSAGE_LENGTH-1) :: interp_method_f
   logical :: src_modulo_f
   logical :: is_latlon_in_f
   logical :: is_latlon_out_f
-  logical :: convert_f_to_c_order, convert_c_to_f_order
 
+  integer :: in_shape(2), out_shape(2)
+  
   CFMS_HORIZ_INTERP_NEW_2D_DATA_TYPE_, allocatable :: lon_in(:,:)
   CFMS_HORIZ_INTERP_NEW_2D_DATA_TYPE_, allocatable :: lat_in(:,:)
   CFMS_HORIZ_INTERP_NEW_2D_DATA_TYPE_, allocatable :: lon_out(:,:)
@@ -36,25 +35,26 @@ function CFMS_HORIZ_INTERP_NEW_2D_(lon_in_ptr, lat_in_ptr, lonlat_in_shape,&
   CFMS_HORIZ_INTERP_NEW_2D_DATA_TYPE_, allocatable :: mask_in(:,:)
   CFMS_HORIZ_INTERP_NEW_2D_DATA_TYPE_, allocatable :: mask_out(:,:)
 
-  allocate(lon_in(lonlat_in_shape(1), lonlat_in_shape(2)))
-  allocate(lat_in(lonlat_in_shape(1), lonlat_in_shape(2)))
-  allocate(lon_out(lonlat_out_shape(1), lonlat_out_shape(2)))
-  allocate(lat_out(lonlat_out_shape(1), lonlat_out_shape(2)))
+  in_shape = (/nlon_in, nlat_in/)
+  out_shape = (/nlon_out, nlat_out/)
+  
+  allocate(lon_in(nlon_in+1, nlat_in+1))
+  allocate(lat_in(nlon_in+1, nlat_in+1))
+  allocate(lon_out(nlon_out+1, nlat_out+1))
+  allocate(lat_out(nlon_out+1, nlat_out+1))
 
-  call cFMS_pointer_to_array(lon_in_ptr, lonlat_in_shape, lon_in, convert_cf_order)
-  call cFMS_pointer_to_array(lat_in_ptr, lonlat_in_shape, lat_in, convert_cf_order)
-  call cFMS_pointer_to_array(lon_out_ptr, lonlat_out_shape, lon_out, convert_cf_order)
-  call cFMS_pointer_to_array(lat_out_ptr, lonlat_out_shape, lat_out, convert_cf_order)
+  call cFMS_pointer_to_array(lon_in_ptr, in_shape+1, lon_in, convert_cf_order)
+  call cFMS_pointer_to_array(lat_in_ptr, in_shape+1, lat_in, convert_cf_order)
+  call cFMS_pointer_to_array(lon_out_ptr, out_shape+1, lon_out, convert_cf_order)
+  call cFMS_pointer_to_array(lat_out_ptr, out_shape+1, lat_out, convert_cf_order)
 
   if(c_associated(mask_in_ptr))  then
-    mask_shape = lonlat_in_shape -1
-    allocate(mask_in(mask_shape(1), mask_shape(2)))
-    call cFMS_pointer_to_array(mask_in_ptr, mask_shape, mask_in, convert_cf_order)
+    allocate(mask_in(nlon_in, nlat_in))
+    call cFMS_pointer_to_array(mask_in_ptr, in_shape, mask_in, convert_cf_order)
   end if
-  if(c_associated(mask_out_ptr)) then
-     mask_shape = lonlat_out_shape -1
-    allocate(mask_out(mask_shape(1), mask_shape(2)))
-    call cFMS_pointer_to_array(mask_out_ptr, mask_shape, mask_out, convert_cf_order)
+  if(c_associated(mask_out_ptr)) then     
+    allocate(mask_out(nlon_out, nlat_out))
+    call cFMS_pointer_to_array(mask_out_ptr, out_shape, mask_out, convert_cf_order)
   end if
 
   interp_method_f = "conservative"

--- a/c_horiz_interp/include/c_horiz_interp_new.inc
+++ b/c_horiz_interp/include/c_horiz_interp_new.inc
@@ -1,6 +1,6 @@
 function CFMS_HORIZ_INTERP_NEW_2D_(lon_in_ptr, lat_in_ptr, lonlat_in_shape,&
      lon_out_ptr, lat_out_ptr, lonlat_out_shape, mask_in_ptr, mask_out_ptr, &
-     interp_method, verbose, max_dist, src_modulo, is_latlon_in, is_latlon_out) &
+     interp_method, verbose, max_dist, src_modulo, is_latlon_in, is_latlon_out, convert_cf_order) &
      bind(C, name=CFMS_HORIZ_INTERP_NEW_2D_BINDC_)
 
   implicit none
@@ -19,6 +19,7 @@ function CFMS_HORIZ_INTERP_NEW_2D_(lon_in_ptr, lat_in_ptr, lonlat_in_shape,&
   logical(c_bool), intent(in), optional :: src_modulo
   logical(c_bool), intent(in), optional :: is_latlon_in
   logical(c_bool), intent(in), optional :: is_latlon_out
+  logical(c_bool), intent(in), optional :: convert_cf_order
 
   integer :: CFMS_HORIZ_INTERP_NEW_2D_
   integer :: mask_shape(2)
@@ -26,6 +27,7 @@ function CFMS_HORIZ_INTERP_NEW_2D_(lon_in_ptr, lat_in_ptr, lonlat_in_shape,&
   logical :: src_modulo_f
   logical :: is_latlon_in_f
   logical :: is_latlon_out_f
+  logical :: convert_f_to_c_order, convert_c_to_f_order
 
   CFMS_HORIZ_INTERP_NEW_2D_DATA_TYPE_, allocatable :: lon_in(:,:)
   CFMS_HORIZ_INTERP_NEW_2D_DATA_TYPE_, allocatable :: lat_in(:,:)
@@ -39,20 +41,20 @@ function CFMS_HORIZ_INTERP_NEW_2D_(lon_in_ptr, lat_in_ptr, lonlat_in_shape,&
   allocate(lon_out(lonlat_out_shape(1), lonlat_out_shape(2)))
   allocate(lat_out(lonlat_out_shape(1), lonlat_out_shape(2)))
 
-  call cFMS_pointer_to_array(lon_in_ptr, lonlat_in_shape, lon_in)
-  call cFMS_pointer_to_array(lat_in_ptr, lonlat_in_shape, lat_in)
-  call cFMS_pointer_to_array(lon_out_ptr, lonlat_out_shape, lon_out)
-  call cFMS_pointer_to_array(lat_out_ptr, lonlat_out_shape, lat_out)
+  call cFMS_pointer_to_array(lon_in_ptr, lonlat_in_shape, lon_in, convert_cf_order)
+  call cFMS_pointer_to_array(lat_in_ptr, lonlat_in_shape, lat_in, convert_cf_order)
+  call cFMS_pointer_to_array(lon_out_ptr, lonlat_out_shape, lon_out, convert_cf_order)
+  call cFMS_pointer_to_array(lat_out_ptr, lonlat_out_shape, lat_out, convert_cf_order)
 
   if(c_associated(mask_in_ptr))  then
     mask_shape = lonlat_in_shape -1
     allocate(mask_in(mask_shape(1), mask_shape(2)))
-    call cFMS_pointer_to_array(mask_in_ptr, mask_shape, mask_in)
+    call cFMS_pointer_to_array(mask_in_ptr, mask_shape, mask_in, convert_cf_order)
   end if
   if(c_associated(mask_out_ptr)) then
      mask_shape = lonlat_out_shape -1
     allocate(mask_out(mask_shape(1), mask_shape(2)))
-    call cFMS_pointer_to_array(mask_out_ptr, mask_shape, mask_out)
+    call cFMS_pointer_to_array(mask_out_ptr, mask_shape, mask_out, convert_cf_order)
   end if
 
   interp_method_f = "conservative"

--- a/test_cfms/c_data_override/test_data_override_2d.c
+++ b/test_cfms/c_data_override/test_data_override_2d.c
@@ -75,6 +75,7 @@ int main()
     int data_shape[2];
     double *data = NULL;
     bool override = false;
+    bool *convert_cf_order = NULL;
 
     int year = 1;
     int month = 1;
@@ -88,7 +89,8 @@ int main()
     data = (double *)malloc(xsize*ysize*sizeof(double));
     
     cFMS_data_override_set_time(&year, &month, &day, &hour, &minute, &second, NULL, NULL);
-    cFMS_data_override_2d_cdouble(gridname, fieldname, data_shape, data, &override, NULL, NULL, NULL, NULL);
+    cFMS_data_override_2d_cdouble(gridname, fieldname, data_shape, data, &override, NULL, NULL, NULL, NULL,
+                                  convert_cf_order);
 
     for(int ij=0; ij<xsize*ysize; ij++) {
       if( ABS(data[ij],100.03) > TOLERANCE ) {

--- a/test_cfms/c_data_override/test_data_override_3d.c
+++ b/test_cfms/c_data_override/test_data_override_3d.c
@@ -77,7 +77,8 @@ int main()
     double *data = NULL;
     int *override_index = NULL;
     bool override = false;
-
+    bool *convert_cf_order = NULL;
+    
     int year = 1;
     int month = 1;
     int day = 4;
@@ -92,7 +93,7 @@ int main()
     
     cFMS_data_override_set_time(&year, &month, &day, &hour, &minute, &second, NULL, NULL);
     cFMS_data_override_3d_cdouble(gridname, fieldname, data_shape, data, &override, 
-                                  override_index, NULL, NULL, NULL, NULL);
+                                  override_index, NULL, NULL, NULL, NULL, convert_cf_order);
 
     int ijk = 0;
     for(int i=0; i<xsize; i++){

--- a/test_cfms/c_diag_manager/test_send_data.c
+++ b/test_cfms/c_diag_manager/test_send_data.c
@@ -242,7 +242,7 @@ int main()
       }
     }
     cFMS_diag_advance_field_time(&id_var3);
-    cFMS_diag_send_data_3d_cfloat(&id_var3, var3_shape, var3, NULL);
+    cFMS_diag_send_data_3d_cfloat(&id_var3, var3_shape, var3, NULL, NULL);
     cFMS_diag_send_complete(&id_var3, NULL);
 
     int ij = 0;
@@ -253,7 +253,7 @@ int main()
       }
     }
     cFMS_diag_advance_field_time(&id_var2);
-    cFMS_diag_send_data_2d_cfloat(&id_var2, var2_shape, var2, NULL);
+    cFMS_diag_send_data_2d_cfloat(&id_var2, var2_shape, var2, NULL, NULL);
     cFMS_diag_send_complete(&id_var2, NULL);    
   }
 

--- a/test_cfms/c_fms/test_update_domains.c
+++ b/test_cfms/c_fms/test_update_domains.c
@@ -195,7 +195,7 @@ void test_float2d(int *domain_id)
   char *name = NULL;
   
   cFMS_update_domains_double_2d(field_shape, idata, domain_id, flags, complete, position,
-                               &whalo, &ehalo, &shalo, &nhalo, name, tile_count);
+                                &whalo, &ehalo, &shalo, &nhalo, name, tile_count, NULL);
 
   int ipe = cFMS_pe();  
   for(int ix=WHALO ; ix<xsize_d-WHALO; ix++) {

--- a/test_cfms/c_fms/test_vector_update_domains.c
+++ b/test_cfms/c_fms/test_vector_update_domains.c
@@ -188,8 +188,8 @@ void test_vector_double2d(int *domain_id)
     char *name = NULL;
 
     cFMS_v_update_domains_double_2d(x_shape, x_data, y_shape, y_data, domain_id, flags,
-                                     &gridtype, complete, &whalo, &ehalo, &shalo, &nhalo,
-                                     name, tile_count);
+                                    &gridtype, complete, &whalo, &ehalo, &shalo, &nhalo,
+                                    name, tile_count, NULL);
 
     /*
     global2r8(nx/2+1:nx, ny+shift) = -global2r8(nx/2:1:-1, ny+shift)

--- a/test_cfms/c_fms_utils/test_utils.F90
+++ b/test_cfms/c_fms_utils/test_utils.F90
@@ -1,37 +1,38 @@
-subroutine test_3d_cdouble(array_shape, c_pointer) bind(C, name="test_3d_cdouble")
+subroutine test_3d_cdouble(nx, ny, nz, c_pointer, convert_cf_order) bind(C, name="test_3d_cdouble")
   
   use c_fms_mod, only: cFMS_error, FATAL
   use c_fms_utils_mod, only : cFMS_pointer_to_array, cFMS_array_to_pointer
   use iso_c_binding  
   
   implicit none
-  integer, intent(in) :: array_shape(3)
+  integer, intent(in) :: nx, ny, nz
   type(c_ptr), value, intent(in) :: c_pointer
+  logical(c_bool), intent(in) :: convert_cf_order
   
   integer :: i, j, k
   real(c_double), allocatable :: f_array(:,:,:)
   real(c_double), allocatable :: answers(:,:,:)
   
-  allocate(answers(array_shape(1),array_shape(2),array_shape(3)))
-  do k=1, array_shape(3)
-     do j=1, array_shape(2)
-        do i=1, array_shape(1)
+  allocate(answers(nx, ny, nz))
+  do k=1, nz
+     do j=1, ny
+        do i=1, nx
            answers(i,j,k) = (i-1)*100+(j-1)*10+(k-1)
         end do
      end do
   end do
-  
-  allocate(f_array(array_shape(1),array_shape(2),array_shape(3)))
-  call cFMS_pointer_to_array(c_pointer, array_shape, f_array)
-  
+
+  allocate(f_array(nx, ny, nz))
+  call cFMS_pointer_to_array(c_pointer, (/nx, ny, nz/), f_array, convert_cf_order)
+
   if(any(answers.ne.f_array)) then
      write(*,*) "ERROR converting pointer to array"
      call cFMS_error(FATAL)
   end if
 
   f_array = - f_array
- 
-  call cFMS_array_to_pointer(f_array, array_shape, c_pointer)
+
+  call cFMS_array_to_pointer(f_array, (/nx, ny, nz/), c_pointer, convert_cf_order)
 
   deallocate(f_array)
   deallocate(answers)

--- a/test_cfms/c_fms_utils/test_utils_c.c
+++ b/test_cfms/c_fms_utils/test_utils_c.c
@@ -1,45 +1,72 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <c_fms.h>
 
-#define NX 10
-#define NY 5
-#define NZ 2
-
-extern void test_3d_cdouble(int *array_shape, double *c_pointer);
+extern void test_3d_cdouble(int *nx, int *ny, int *nz, double *c_pointer, bool *convert_cf_order);
 
 int main()
 {
 
+  int nx = 10, ny = 5, nz = 2;
   double *array_3d;
-  int shape[3] = {NX, NY, NZ};
   int ijk;
+  bool convert_cf_order;
   
-  array_3d = (double *)malloc(NX*NY*NZ*sizeof(double));
-  
-  ijk = 0;
-  for(int i=0; i<NX; i++){
-    for(int j=0; j<NY; j++){
-      for(int k=0; k<NZ; k++){
-        array_3d[ijk++] = i*100. + j*10. + k*1.;
+  array_3d = (double *)malloc(nx*ny*nz*sizeof(double));
+
+  convert_cf_order = true;
+  {
+    ijk = 0;
+    for(int i=0; i<nx; i++){
+      for(int j=0; j<ny; j++){
+        for(int k=0; k<nz; k++){
+          array_3d[ijk++] = i*100. + j*10. + k*1.;
+        }
       }
     }
-  }
-
-  test_3d_cdouble(shape, array_3d);
-  
-  ijk = 0;
-  for(int i=0; i<NX; i++){
-    for(int j=0; j<NY; j++){
-      for(int k=0; k<NZ; k++){
-        if(array_3d[ijk++] != -i*100. - j*10. - k*1.) {
-          cFMS_error(FATAL, "ERROR CONVERTING ARRAY TO POINTER");
-          exit(EXIT_FAILURE);
+    
+    test_3d_cdouble(&nx, &ny, &nz, array_3d, &convert_cf_order);
+    
+    ijk = 0;
+    for(int i=0; i<nx; i++){
+      for(int j=0; j<ny; j++){
+        for(int k=0; k<nz; k++){
+          if(array_3d[ijk++] != -i*100. - j*10. - k*1.) {
+            cFMS_error(FATAL, "ERROR CONVERTING ARRAY TO POINTER");
+            exit(EXIT_FAILURE);
+          }
         }
       }
     }
   }
-  
+
+  convert_cf_order = false;
+  {
+    ijk = 0;
+    for(int k=0; k<nz; k++){
+      for(int j=0; j<ny; j++){
+        for(int i=0; i<nx; i++){
+          array_3d[ijk++] = i*100. + j*10. + k*1.;
+        }
+      }
+    }
+    
+    test_3d_cdouble(&nx, &ny, &nz, array_3d, &convert_cf_order);
+
+    ijk = 0;
+    for(int k=0; k<nz; k++){
+      for(int j=0; j<ny; j++){
+        for(int i=0; i<nx; i++){
+          if(array_3d[ijk++] != -i*100. - j*10. - k*1.) {
+            cFMS_error(FATAL, "ERROR CONVERTING ARRAY TO POINTER");
+            exit(EXIT_FAILURE);
+          }
+        }
+      }
+    }
+  }
+
   return EXIT_SUCCESS;
   
 }

--- a/test_cfms/c_horiz_interp/test_horiz_interp_base.c
+++ b/test_cfms/c_horiz_interp/test_horiz_interp_base.c
@@ -6,66 +6,27 @@
 #include "c_horiz_interp.h"
 #include "c_fms.h"
 
-int Nin = 5;
-int Nout = 5;
-double din = 0.5; //degrees
-double dout = 0.5; //degrees
+void set_grid(double *lon_in, double *lat_in, double *lon_out, double *lat_out, char order);
+void set_data(double *data_in, char order);
+
+int nin = 5, nout = 5;
+double din = 0.5, dout = 0.5;  
 
 int main()
 {
-   
+
   double *lon_in, *lat_in;
   double *lon_out, *lat_out;
-  double *data_in;
-  double *data_out;
+  double *data_in, *data_out;
 
-  int lonlat_in_shape[2] = {Nin+1, Nin+1};
-  int lonlat_out_shape[2] = {Nout+1, Nout+1};
-  int data_in_shape[2] = {Nin, Nin};
-  int data_out_shape[2] = {Nout, Nout};
+  lon_in = (double *)malloc((nin+1)*(nin+1)*sizeof(double));
+  lat_in = (double *)malloc((nin+1)*(nin+1)*sizeof(double));
+  lon_out = (double *)malloc((nout+1)*(nout+1)*sizeof(double));
+  lat_out = (double *)malloc((nout+1)*(nout+1)*sizeof(double));
 
-  lon_in = (double *)malloc((Nin+1)*(Nin+1)*sizeof(double));
-  lat_in = (double *)malloc((Nin+1)*(Nin+1)*sizeof(double));
-  lon_out = (double *)malloc((Nout+1)*(Nout+1)*sizeof(double));
-  lat_out = (double *)malloc((Nout+1)*(Nout+1)*sizeof(double));
+  data_in = (double *)malloc(nin*nin*sizeof(double));
+  data_out = (double *)calloc(nout*nout, sizeof(double));
 
-  data_in = (double *)malloc(Nin*Nin*sizeof(double));
-  data_out = (double *)malloc(Nout*Nout*sizeof(double));
-
-  //input grid
-  for(int i=0; i<Nin+1; i++){
-    for(int j=0; j<Nin+1; j++){
-      int ij = i*(Nin+1) + j;
-      lon_in[ij] = (double)i*din*DEG_TO_RAD;
-      lat_in[ij] = (double)j*din*DEG_TO_RAD;
-    }
-  }
-
-  //output grid
-  for(int i=0; i<Nout+1; i++){
-    for(int j=0; j<Nout+1; j++){
-      int ij = i*(Nout+1) + j;
-      lon_out[ij] = (double)i*dout*DEG_TO_RAD;
-      lat_out[ij] = (double)j*dout*DEG_TO_RAD;
-    }
-  }
-  
-  //input data
-  for(int j=0; j<Nin; j++){
-    for(int i=0; i<Nin; i++){
-      int ij = j*Nin + i;
-      data_in[ij] = (double)ij;
-    }
-  }
-
-  //initialize output data
-  for(int j=0; j<Nout; j++){
-    for(int i=0; i<Nout; i++){
-      int ij = j*Nout + i;
-      data_out[ij] = 0.0;
-    }
-  }
-  
   char interp_method[MESSAGE_LENGTH] = "conservative";
   int *verbose = NULL;
   double *max_dist = NULL;
@@ -74,29 +35,127 @@ int main()
   double *mask_out = NULL;
   bool *is_latlon_in = NULL;
   bool *is_latlon_out = NULL;
-
-  int one = 1;
-  
-  cFMS_init(NULL,NULL,NULL,NULL,NULL);
-  cFMS_horiz_interp_init(&one);
-  int interp = cFMS_horiz_interp_new_2d_cdouble(lon_in, lat_in, lonlat_in_shape,
-                                                lon_out, lat_out, lonlat_out_shape,
-                                                mask_in, mask_out, interp_method,
-                                                verbose, max_dist, src_modulo,
-                                                is_latlon_in, is_latlon_out);
-  
-  
   double *missing_value = NULL;
   int *missing_permit = NULL;
   bool *new_missing_handle = NULL;
-  cFMS_horiz_interp_base_2d_cdouble(&interp, data_in, data_in_shape, data_out, data_out_shape,
-                                    mask_in, mask_out, verbose, missing_value, missing_permit,
-                                    new_missing_handle);
+    
+  cFMS_init(NULL,NULL,NULL,NULL,NULL);
+  int two = 2; cFMS_horiz_interp_init(&two);
 
-  for(int i=0; i<Nout*Nout; i++) assert(data_out[i] == (double)i);
+  bool convert_cf_order;
+
+  convert_cf_order = true;
+  {
+    set_grid(lon_in, lat_in, lon_out, lat_out, 'C');    
+    int interp = cFMS_horiz_interp_new_2d_cdouble(&nin, &nin, &nout, &nout,
+                                                  lon_in, lat_in, lon_out, lat_out,
+                                                  mask_in, mask_out, interp_method,
+                                                  verbose, max_dist, src_modulo,
+                                                  is_latlon_in, is_latlon_out, &convert_cf_order);
+
+    set_data(data_in, 'C');
+    cFMS_horiz_interp_base_2d_cdouble(&interp, data_in, data_out, mask_in, mask_out, verbose, missing_value,
+                                      missing_permit, new_missing_handle, &convert_cf_order);
+        
+    int ij = 0;
+    for(int i=0; i<nout; i++){
+      for(int j=0; j<nout; j++){
+        assert(data_out[ij++] == (double)i);
+      }
+    }
+  }
+
+  convert_cf_order = false;
+  {
+    set_grid(lon_in, lat_in, lon_out, lat_out, 'F');
+    int interp = cFMS_horiz_interp_new_2d_cdouble(&nin, &nin, &nout, &nout,
+                                                  lon_in, lat_in, lon_out, lat_out,
+                                                  mask_in, mask_out, interp_method,
+                                                  verbose, max_dist, src_modulo,
+                                                  is_latlon_in, is_latlon_out, &convert_cf_order);
+
+    set_data(data_in, 'F');
+    cFMS_horiz_interp_base_2d_cdouble(&interp, data_in, data_out, mask_in, mask_out, verbose, missing_value,
+                                      missing_permit, new_missing_handle, &convert_cf_order);
+
+    int ij = 0;
+    for(int j=0; j<nout; j++){
+      for(int i=0; i<nout; i++){
+        assert(data_out[ij++] == (double)i);
+      }
+    }
+  }
 
   cFMS_horiz_interp_end();
+  cFMS_end();
   
   return EXIT_SUCCESS;
 
 }
+
+void set_grid(double *lon_in, double *lat_in, double *lon_out, double *lat_out, char order)
+{
+
+  char C = 'C';
+  
+  if(order == C){
+    for(int i=0; i<nin+1; i++){
+      for(int j=0; j<nin+1; j++){
+        int ij = i*(nin+1) + j;
+        lon_in[ij] = (double)i*din*DEG_TO_RAD;
+        lat_in[ij] = (double)j*din*DEG_TO_RAD;
+      }
+    }
+    for(int i=0; i<nout+1; i++){
+      for(int j=0; j<nout+1; j++){
+        int ij = i*(nout+1) + j;
+        lon_out[ij] = (double)i*dout*DEG_TO_RAD;
+        lat_out[ij] = (double)j*dout*DEG_TO_RAD;
+      }
+    }
+  }
+  else { //fortran ordered    
+    for(int j=0; j<nin+1; j++){
+      for(int i=0; i<nin+1; i++){
+        int ij = j*(nin+1) + i;
+        lon_in[ij] = (double)i*din*DEG_TO_RAD;
+        lat_in[ij] = (double)j*din*DEG_TO_RAD;
+      }
+    }
+    for(int j=0; j<nout+1; j++){
+      for(int i=0; i<nout+1; i++){
+        int ij = j*(nout+1) + i;
+        lon_out[ij] = (double)i*dout*DEG_TO_RAD;
+        lat_out[ij] = (double)j*dout*DEG_TO_RAD;
+      }
+    }    
+  }//if
+
+}
+
+void set_data(double *data_in, char order)
+{
+
+  char C = 'C';
+  
+  if(order == C) {
+    for(int i=0; i<nin; i++){
+      for(int j=0; j<nin; j++){
+        int ij = i*nin + j;
+        data_in[ij] = (double)i;
+      }
+    }
+  }
+  else {
+    for(int j=0; j<nin; j++){
+      for(int i=0; i<nin; i++){
+        int ij = j*nin + i;
+        data_in[ij] = (double)i;
+      }
+    }
+  }
+
+}
+  
+
+  

--- a/test_cfms/c_horiz_interp/test_horiz_interp_base.c
+++ b/test_cfms/c_horiz_interp/test_horiz_interp_base.c
@@ -10,7 +10,7 @@ void set_grid(double *lon_in, double *lat_in, double *lon_out, double *lat_out, 
 void set_data(double *data_in, char order);
 
 int nin = 5, nout = 5;
-double din = 0.5, dout = 0.5;  
+double din = 0.5, dout = 0.5;
 
 int main()
 {
@@ -38,7 +38,7 @@ int main()
   double *missing_value = NULL;
   int *missing_permit = NULL;
   bool *new_missing_handle = NULL;
-    
+
   cFMS_init(NULL,NULL,NULL,NULL,NULL);
   int two = 2; cFMS_horiz_interp_init(&two);
 
@@ -46,7 +46,7 @@ int main()
 
   convert_cf_order = true;
   {
-    set_grid(lon_in, lat_in, lon_out, lat_out, 'C');    
+    set_grid(lon_in, lat_in, lon_out, lat_out, 'C');
     int interp = cFMS_horiz_interp_new_2d_cdouble(&nin, &nin, &nout, &nout,
                                                   lon_in, lat_in, lon_out, lat_out,
                                                   mask_in, mask_out, interp_method,
@@ -56,7 +56,7 @@ int main()
     set_data(data_in, 'C');
     cFMS_horiz_interp_base_2d_cdouble(&interp, data_in, data_out, mask_in, mask_out, verbose, missing_value,
                                       missing_permit, new_missing_handle, &convert_cf_order);
-        
+
     int ij = 0;
     for(int i=0; i<nout; i++){
       for(int j=0; j<nout; j++){
@@ -88,7 +88,7 @@ int main()
 
   cFMS_horiz_interp_end();
   cFMS_end();
-  
+
   return EXIT_SUCCESS;
 
 }
@@ -97,7 +97,7 @@ void set_grid(double *lon_in, double *lat_in, double *lon_out, double *lat_out, 
 {
 
   char C = 'C';
-  
+
   if(order == C){
     for(int i=0; i<nin+1; i++){
       for(int j=0; j<nin+1; j++){
@@ -114,7 +114,7 @@ void set_grid(double *lon_in, double *lat_in, double *lon_out, double *lat_out, 
       }
     }
   }
-  else { //fortran ordered    
+  else { //fortran ordered
     for(int j=0; j<nin+1; j++){
       for(int i=0; i<nin+1; i++){
         int ij = j*(nin+1) + i;
@@ -128,7 +128,7 @@ void set_grid(double *lon_in, double *lat_in, double *lon_out, double *lat_out, 
         lon_out[ij] = (double)i*dout*DEG_TO_RAD;
         lat_out[ij] = (double)j*dout*DEG_TO_RAD;
       }
-    }    
+    }
   }//if
 
 }
@@ -137,7 +137,7 @@ void set_data(double *data_in, char order)
 {
 
   char C = 'C';
-  
+
   if(order == C) {
     for(int i=0; i<nin; i++){
       for(int j=0; j<nin; j++){
@@ -156,6 +156,3 @@ void set_data(double *data_in, char order)
   }
 
 }
-  
-
-  

--- a/test_cfms/c_horiz_interp/test_horiz_interp_new.c
+++ b/test_cfms/c_horiz_interp/test_horiz_interp_new.c
@@ -40,13 +40,13 @@ int main(){
 
   cFMS_horiz_interp_init(&ninterp);
 
-  printf("starting conservative test...");
+  //printf("starting conservative test...\n");
   test_conserve = test_conservative_new(domain_id);
-  printf("done.\n");
+  //printf("done.\n");
 
   /*
   bilinear test needs to be fixed
-  printf("starting bilinear test...");
+  printf("starting bilinear test...\n");
   test_bilinear = test_bilinear_new(domain_id);
   printf("done.\n");
   */
@@ -126,7 +126,7 @@ int test_conservative_new(int domain_id)
     double SMALL = 1.0e-10;
 
     char interp_method[MESSAGE_LENGTH] = "conservative";
-
+    
     dlon_src = (lon_src_end-lon_src_beg)/NI_SRC;
     dlat_src = (lat_src_end-lat_src_beg)/NJ_SRC;
     dlon_dst = (lon_dst_end-lon_dst_beg)/NI_DST;
@@ -195,15 +195,19 @@ int test_conservative_new(int domain_id)
             lat_out_2D[lat_out_1d_size*i + j] = lat_out_1D[j];
         }
     }
-    int lat_out_shape[2] = {lon_out_1d_size, lat_out_1d_size};
 
     int interp_id = 0;
     int test_interp_id;
 
-    test_interp_id = cFMS_horiz_interp_new_2d_cdouble(lon_in_2D, lat_in_2D, lat_in_shape,
-                                                      lon_out_2D, lat_out_2D, lat_out_shape,
+    int nlon_in = lon_in_1d_size - 1;
+    int nlat_in = lat_in_1d_size - 1;
+    int nlon_out = lon_out_1d_size - 1;
+    int nlat_out = lat_out_1d_size - 1;
+    
+    test_interp_id = cFMS_horiz_interp_new_2d_cdouble(&nlon_in, &nlat_in, &nlon_out, &nlat_out,
+                                                      lon_in_2D, lat_in_2D, lon_out_2D, lat_out_2D,
                                                       NULL, NULL, interp_method, NULL, NULL,
-                                                      NULL, NULL, NULL);
+                                                      NULL, NULL, NULL, NULL);
 
     assert(test_interp_id == interp_id);
 
@@ -374,12 +378,11 @@ int test_bilinear_new(int domain_id)
     int interp_id = 1;
     int test_interp_id;
 
-    test_interp_id = cFMS_horiz_interp_new_2d_cdouble(lon_in_2D, lat_in_2D, lat_in_shape,
-                                                      lon_out_2D, lat_out_2D, lat_out_shape,
+    test_interp_id = cFMS_horiz_interp_new_2d_cdouble(&lon_in_1d_size, &lat_in_1d_size, &lon_out_1d_size,
+                                                      &lat_out_1d_size, lon_in_2D, lat_in_2D, lon_out_2D, lat_out_2D,
                                                       NULL, NULL, interp_method, NULL, NULL,
-                                                      NULL, NULL, NULL);
-    
-    printf("ids %d %d\n", test_interp_id, interp_id);
+                                                      NULL, NULL, NULL, NULL);
+
     assert(test_interp_id == interp_id);
     
     int nlon_src;


### PR DESCRIPTION
This PR adds

1.  option to skip re-ordering data from supposed C order to F order in `cFMS_pointer_to_array`
2.  option to skip re-ordering data from F to C order in `cFMS_array_to_pointer`
3.  adds the optional argument to all subroutines with in/out array variables
4.  change `horiz_interp` subroutine arguments.  Users now need to provide nx and ny dimensions explicitly, rather than specifying the shape of the passed in arrays.
5.  updates tests