### PR TITLE
Fix indexing in horiz_interp_end

### DIFF
--- a/c_horiz_interp/c_horiz_interp.F90
+++ b/c_horiz_interp/c_horiz_interp.F90
@@ -108,7 +108,7 @@ contains
     implicit none
     integer :: i
     
-    do i=1, size(interp)
+    do i=0, size(interp)-1
        call fms_horiz_interp_del(interp(i))
     end do
     deallocate(interp)

--- a/c_horiz_interp/include/c_horiz_interp_base.inc
+++ b/c_horiz_interp/include/c_horiz_interp_base.inc
@@ -32,6 +32,7 @@ subroutine CFMS_HORIZ_INTERP_BASE_2D_(interp_id, data_in_ptr, data_out_ptr, &
 
   in_shape = (/nlon_in, nlat_in/)
   out_shape = (/nlon_out, nlat_out/)
+
   allocate(data_in(nlon_in, nlat_in))
   allocate(data_out(nlon_out, nlat_out))
 

--- a/c_horiz_interp/include/c_horiz_interp_base.inc
+++ b/c_horiz_interp/include/c_horiz_interp_base.inc
@@ -32,7 +32,6 @@ subroutine CFMS_HORIZ_INTERP_BASE_2D_(interp_id, data_in_ptr, data_out_ptr, &
 
   in_shape = (/nlon_in, nlat_in/)
   out_shape = (/nlon_out, nlat_out/)
-
   allocate(data_in(nlon_in, nlat_in))
   allocate(data_out(nlon_out, nlat_out))
 

--- a/c_horiz_interp/include/c_horiz_interp_base.inc
+++ b/c_horiz_interp/include/c_horiz_interp_base.inc
@@ -32,7 +32,7 @@ subroutine CFMS_HORIZ_INTERP_BASE_2D_(interp_id, data_in_ptr, data_out_ptr, &
 
   in_shape = (/nlon_in, nlat_in/)
   out_shape = (/nlon_out, nlat_out/)
-  
+
   allocate(data_in(nlon_in, nlat_in))
   allocate(data_out(nlon_out, nlat_out))
 


### PR DESCRIPTION
When allocating the interp array in `c_horiz_interp_init`, indexing is set to start from `zero`, _.e.g,_ 
```
allocate  interp(0:2)
```
When deallocating the interp array in `c_horiz_inter_end`, the do loop index starts from `one`, which leads to out of bounds error when the do loops reaches the last index, which is size(interp)=3 for the given example
```
do i=1, size(interp)
     deallocate(interp(i)
 end do
```

This PR fixes the do loop index to start from 0.