### PR TITLE
clean up cFMS_gather routines

### DIFF
--- a/c_fms/c_fms.h
+++ b/c_fms/c_fms.h
@@ -87,14 +87,14 @@ extern void cFMS_gather_1d_cfloat(int* sbuf_size, float* sbuf, float* rbuf, int*
 
 extern void cFMS_gather_1d_cdouble(int* sbuf_size, double* sbuf, double* rbuf, int* pelist, int* rbuf_size, int* npes);
 
-extern void cFMS_gatherv_1d_cint(int* npes, int* sbuf_size, int* sbuf, int* ssize,
-  int* rbuf, int* rsize, int* pelist);
+extern void cFMS_gatherv_1d_cint(int* sbuf_size, int* sbuf, int* ssize,
+  int* rbuf, int* rsize, int* pelist, int* npes);
 
-extern void cFMS_gatherv_1d_cfloat(int* npes, int* sbuf_size, float* sbuf, int* ssize,
-  float* rbuf, int* rsize, int* pelist);
+extern void cFMS_gatherv_1d_cfloat(int* sbuf_size, float* sbuf, int* ssize,
+  float* rbuf, int* rsize, int* pelist, int* npes);
 
-extern void cFMS_gatherv_1d_cdouble(int* npes, int* sbuf_size, double* sbuf, int* ssize,
-  double* rbuf, int* rsize, int* pelist);
+extern void cFMS_gatherv_1d_cdouble(int* sbuf_size, double* sbuf, int* ssize,
+  double* rbuf, int* rsize, int* pelist, int* npes);
 
 extern void cFMS_gather_pelist_2d_cint(int* is, int* ie, int* js, int* je, int* npes, int* pelist,
   int* array_seg, int* gather_data, bool* is_root_pe,

--- a/c_fms/c_fms.h
+++ b/c_fms/c_fms.h
@@ -81,11 +81,11 @@ extern int cFMS_define_nest_domains(int* num_nest, int* ntiles, int* nest_level,
 
 extern bool cFMS_domain_is_initialized(int* domain_id);
 
-extern void cFMS_gather_1d_cint(int* sbuf_size, int* rbuf_size, int* sbuf, int* rbuf, int* pelist, int* npes);
+extern void cFMS_gather_1d_cint(int* sbuf_size, int* sbuf, int* rbuf, int* pelist, int *rbuf_size, int* npes);
 
-extern void cFMS_gather_1d_cfloat(int* sbuf_size, int* rbuf_size, float* sbuf, float* rbuf, int* pelist, int* npes);
+extern void cFMS_gather_1d_cfloat(int* sbuf_size, float* sbuf, float* rbuf, int* pelist, int *rbuf_size, int* npes);
 
-extern void cFMS_gather_1d_cdouble(int* sbuf_size, int* rbuf_size, double* sbuf, double* rbuf, int* pelist, int* npes);
+extern void cFMS_gather_1d_cdouble(int* sbuf_size, double* sbuf, double* rbuf, int* pelist, int *rbuf_size, int* npes);
 
 extern void cFMS_gatherv_1d_cint(int* npes, int* sbuf_size, int* rbuf_size, int* sbuf, int* ssize,
     int* rbuf, int* rsize, int* pelist);

--- a/c_fms/c_fms.h
+++ b/c_fms/c_fms.h
@@ -64,174 +64,174 @@ extern int cFMS_pe();
 extern void cFMS_set_current_pelist(int* npes, int* pelist, bool* no_sync);
 
 extern int cFMS_define_domains(int* global_indices, int* layout, int* npes, int* pelist,
-    int* xflags, int* yflags, int* xhalo, int* yhalo, int* xextent, int* yextent,
-    bool* maskmap, char* name, bool* symmetry, int* memory_size,
-    int* whalo, int* ehalo, int* shalo, int* nhalo, bool* is_mosaic,
-    int* tile_count, int* tile_id, bool* complete, int* x_cyclic_offset,
-    int* y_cyclic_offset);
+  int* xflags, int* yflags, int* xhalo, int* yhalo, int* xextent, int* yextent,
+  bool* maskmap, char* name, bool* symmetry, int* memory_size,
+  int* whalo, int* ehalo, int* shalo, int* nhalo, bool* is_mosaic,
+  int* tile_count, int* tile_id, bool* complete, int* x_cyclic_offset,
+  int* y_cyclic_offset);
 
 extern void cFMS_define_io_domain(int* io_layout, int* domain_id);
 
 extern void cFMS_define_layout(int* global_indices, int* ndivs, int* layout);
 
 extern int cFMS_define_nest_domains(int* num_nest, int* ntiles, int* nest_level, int* tile_fine, int* tile_course,
-    int* istart_coarse, int* icount_coarse, int* jstart_coarse, int* jcount_coarse,
-    int* npes_nest_tile, int* x_refine, int* y_refine, int* domain_id,
-    int* extra_halo, char* name);
+  int* istart_coarse, int* icount_coarse, int* jstart_coarse, int* jcount_coarse,
+  int* npes_nest_tile, int* x_refine, int* y_refine, int* domain_id,
+  int* extra_halo, char* name);
 
 extern bool cFMS_domain_is_initialized(int* domain_id);
 
-extern void cFMS_gather_1d_cint(int* sbuf_size, int* sbuf, int* rbuf, int* pelist, int *rbuf_size, int* npes);
+extern void cFMS_gather_1d_cint(int* sbuf_size, int* sbuf, int* rbuf, int* pelist, int* rbuf_size, int* npes);
 
-extern void cFMS_gather_1d_cfloat(int* sbuf_size, float* sbuf, float* rbuf, int* pelist, int *rbuf_size, int* npes);
+extern void cFMS_gather_1d_cfloat(int* sbuf_size, float* sbuf, float* rbuf, int* pelist, int* rbuf_size, int* npes);
 
-extern void cFMS_gather_1d_cdouble(int* sbuf_size, double* sbuf, double* rbuf, int* pelist, int *rbuf_size, int* npes);
+extern void cFMS_gather_1d_cdouble(int* sbuf_size, double* sbuf, double* rbuf, int* pelist, int* rbuf_size, int* npes);
 
-extern void cFMS_gatherv_1d_cint(int* npes, int* sbuf_size, int* rbuf_size, int* sbuf, int* ssize,
-    int* rbuf, int* rsize, int* pelist);
+extern void cFMS_gatherv_1d_cint(int* npes, int* sbuf_size, int* sbuf, int* ssize,
+  int* rbuf, int* rsize, int* pelist);
 
-extern void cFMS_gatherv_1d_cfloat(int* npes, int* sbuf_size, int* rbuf_size, float* sbuf, int* ssize,
-    float* rbuf, int* rsize, int* pelist);
+extern void cFMS_gatherv_1d_cfloat(int* npes, int* sbuf_size, float* sbuf, int* ssize,
+  float* rbuf, int* rsize, int* pelist);
 
-extern void cFMS_gatherv_1d_cdouble(int* npes, int* sbuf_size, int* rbuf_size, double* sbuf, int* ssize,
-    double* rbuf, int* rsize, int* pelist);
+extern void cFMS_gatherv_1d_cdouble(int* npes, int* sbuf_size, double* sbuf, int* ssize,
+  double* rbuf, int* rsize, int* pelist);
 
 extern void cFMS_gather_pelist_2d_cint(int* is, int* ie, int* js, int* je, int* npes, int* pelist,
-                                       int* array_seg, int* gather_data, bool* is_root_pe, 
-                                       int *gather_data_c_shape, int* ishift, int* jshift, bool* convert_cf_order);
+  int* array_seg, int* gather_data, bool* is_root_pe,
+  int* gather_data_c_shape, int* ishift, int* jshift, bool* convert_cf_order);
 
 extern void cFMS_gather_pelist_2d_cfloat(int* is, int* ie, int* js, int* je, int* npes, int* pelist,
-                                         float* array_seg, float* gather_data, bool *is_root_pe,
-                                         int* gather_data_c_shape, int* ishift, int* jshift, bool* convert_cf_order);
+  float* array_seg, float* gather_data, bool* is_root_pe,
+  int* gather_data_c_shape, int* ishift, int* jshift, bool* convert_cf_order);
 
 extern void cFMS_gather_pelist_2d_cdouble(int* is, int* ie, int* js, int* je, int* npes, int* pelist,
-                                          double* array_seg, double* gather_data, bool* is_root_pe,
-                                           int* gather_data_c_shape, int* ishift, int* jshift, bool* convert_cf_order);
+  double* array_seg, double* gather_data, bool* is_root_pe,
+  int* gather_data_c_shape, int* ishift, int* jshift, bool* convert_cf_order);
 
 extern void cFMS_get_compute_domain(int* domain_id, int* xbegin, int* xend, int* ybegin, int* yend,
-    int* xsize, int* xmax_size, int* ysize, int* ymax_size,
-    bool* x_is_global, bool* y_is_global, int* tile_count, int* position,
-    int* whalo, int* shalo);
+  int* xsize, int* xmax_size, int* ysize, int* ymax_size,
+  bool* x_is_global, bool* y_is_global, int* tile_count, int* position,
+  int* whalo, int* shalo);
 
 extern void cFMS_get_data_domain(int* domain_id, int* xbegin, int* xend, int* ybegin, int* yend,
-    int* xsize, int* xmax_size, int* ysize, int* ymax_size,
-    bool* x_is_global, bool* y_is_global, int* tile_count, int* position,
-    int* whalo, int* shalo);
+  int* xsize, int* xmax_size, int* ysize, int* ymax_size,
+  bool* x_is_global, bool* y_is_global, int* tile_count, int* position,
+  int* whalo, int* shalo);
 
 extern void cFMS_get_domain_name(char* domain_name_c, int* domain_id);
 
 extern void cFMS_get_domain_pelist(int* npes, int* pelist, int* domain_id);
 
 extern void cFMS_get_global_domain(int* domain_id, int* xbegin, int* xend, int* ybegin, int* yend,
-    int* xsize, int* xmax_size, int* ysize, int* ymax_size,
-    int* tile_count, int* position, int* whalo, int* shalo);
+  int* xsize, int* xmax_size, int* ysize, int* ymax_size,
+  int* tile_count, int* position, int* whalo, int* shalo);
 
 extern void cFMS_get_layout(int* layout, int* domain_id);
 
 extern int cFMS_root_pe();
 
 extern void cFMS_set_compute_domain(int* domain_id, int* xbegin, int* xend, int* ybegin, int* yend,
-    int* xsize, int* ysize, bool* x_is_global, bool* y_is_global, int* tile_count,
-    int* whalo, int* shalo);
+  int* xsize, int* ysize, bool* x_is_global, bool* y_is_global, int* tile_count,
+  int* whalo, int* shalo);
 
 extern void cFMS_set_current_domain(int* domain_id);
 
 extern void cFMS_set_data_domain(int* domain_id, int* xbegin, int* xend, int* ybegin, int* yend,
-    int* xsize, int* ysize, bool* x_is_global, bool* y_is_global, int* tile_count,
-    int* whalo, int* shalo);
+  int* xsize, int* ysize, bool* x_is_global, bool* y_is_global, int* tile_count,
+  int* whalo, int* shalo);
 
 extern void cFMS_set_global_domain(int* domain_id, int* xbegin, int* xend, int* ybegin, int* yend,
-    int* xsize, int* ysize, int* tile_count);
+  int* xsize, int* ysize, int* tile_count);
 
 extern void cFMS_update_domains_double_2d(int* field_shape, double* field, int* domain_id, int* flags, int* complete,
-    int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern void cFMS_update_domains_double_3d(int* field_shape, double* field, int* domain_id, int* flags, int* complete,
-    int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern void cFMS_update_domains_double_4d(int* field_shape, double* field, int* domain_id, int* flags, int* complete,
-    int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern void cFMS_update_domains_double_5d(int* field_shape, double* field, int* domain_id, int* flags, int* complete,
-    int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern void cFMS_update_domains_float_2d(int* field_shape, float* field, int* domain_id, int* flags, int* complete,
-    int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern void cFMS_update_domains_float_3d(int* field_shape, float* field, int* domain_id, int* flags, int* complete,
-    int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern void cFMS_update_domains_float_4d(int* field_shape, float* field, int* domain_id, int* flags, int* complete,
-    int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern void cFMS_update_domains_float_5d(int* field_shape, float* field, int* domain_id, int* flags, int* complete,
-    int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern void cFMS_update_domains_int_2d(int* field_shape, int* field, int* domain_id, int* flags, int* complete,
-    int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern void cFMS_update_domains_int_3d(int* field_shape, int* field, int* domain_id, int* flags, int* complete,
-    int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern void cFMS_update_domains_int_4d(int* field_shape, int* field, int* domain_id, int* flags, int* complete,
-    int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern void cFMS_update_domains_int_5d(int* field_shape, int* field, int* domain_id, int* flags, int* complete,
-    int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern void cFMS_v_update_domains_double_2d(int* fieldx_shape, double* fieldx, int* fieldy_shape, double* fieldy,
-    int* domain_id, int* flags, int* gridtype, int* complete,
-    int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* domain_id, int* flags, int* gridtype, int* complete,
+  int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern void cFMS_v_update_domains_double_3d(int* fieldx_shape, double* fieldx, int* fieldy_shape, double* fieldy,
-    int* domain_id, int* flags, int* gridtype, int* complete,
-    int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* domain_id, int* flags, int* gridtype, int* complete,
+  int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern void cFMS_v_update_domains_double_4d(int* fieldx_shape, double* fieldx, int* fieldy_shape, double* fieldy,
-    int* domain_id, int* flags, int* gridtype, int* complete,
-    int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* domain_id, int* flags, int* gridtype, int* complete,
+  int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern void cFMS_v_update_domains_double_5d(int* fieldx_shape, double* fieldx, int* fieldy_shape, double* fieldy,
-    int* domain_id, int* flags, int* gridtype, int* complete,
-    int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* domain_id, int* flags, int* gridtype, int* complete,
+  int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern void cFMS_v_update_domains_float_2d(int* fieldx_shape, float* fieldx, int* fieldy_shape, float* fieldy,
-    int* domain_id, int* flags, int* gridtype, int* complete,
-    int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* domain_id, int* flags, int* gridtype, int* complete,
+  int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern void cFMS_v_update_domains_float_3d(int* fieldx_shape, float* fieldx, int* fieldy_shape, float* fieldy,
-    int* domain_id, int* flags, int* gridtype, int* complete,
-    int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* domain_id, int* flags, int* gridtype, int* complete,
+  int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern void cFMS_v_update_domains_float_4d(int* fieldx_shape, float* fieldx, int* fieldy_shape, float* fieldy,
-    int* domain_id, int* flags, int* gridtype, int* complete,
-    int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* domain_id, int* flags, int* gridtype, int* complete,
+  int* position, int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern void cFMS_v_update_domains_float_5d(int* fieldx_shape, float* fieldx, int** fieldy_shape, float* fieldy,
-    int* domain_id, int* flags, int* gridtype, int* complete,
-    int* whalo, int* ehalo, int* shalo, int* nhalo,
-    char* name, int* tile_count, bool* convert_cf_order);
+  int* domain_id, int* flags, int* gridtype, int* complete,
+  int* whalo, int* ehalo, int* shalo, int* nhalo,
+  char* name, int* tile_count, bool* convert_cf_order);
 
 extern int cFMS_define_cubic_mosaic(int* ni, int* nj, int* global_indices, int* layout, int* ntiles,
-    int* halo, bool* use_memsize);
+  int* halo, bool* use_memsize);
 
 #endif

--- a/c_fms/c_fms.h
+++ b/c_fms/c_fms.h
@@ -97,16 +97,16 @@ extern void cFMS_gatherv_1d_cdouble(int* npes, int* sbuf_size, int* rbuf_size, d
     double* rbuf, int* rsize, int* pelist);
 
 extern void cFMS_gather_pelist_2d_cint(int* is, int* ie, int* js, int* je, int* npes, int* pelist,
-    int* array_seg, int* gather_data_c_shape, int* gather_data,
-    bool* is_root_pe, int* ishift, int* jshift, bool* convert_cf_order);
+                                       int* array_seg, int* gather_data, bool* is_root_pe, 
+                                       int *gather_data_c_shape, int* ishift, int* jshift, bool* convert_cf_order);
 
 extern void cFMS_gather_pelist_2d_cfloat(int* is, int* ie, int* js, int* je, int* npes, int* pelist,
-    float* array_seg, int* gather_data_c_shape, float* gather_data,
-    bool* is_root_pe, int* ishift, int* jshift, bool* convert_cf_order);
+                                         float* array_seg, float* gather_data, bool *is_root_pe,
+                                         int* gather_data_c_shape, int* ishift, int* jshift, bool* convert_cf_order);
 
 extern void cFMS_gather_pelist_2d_cdouble(int* is, int* ie, int* js, int* je, int* npes, int* pelist,
-    double* array_seg, int* gather_data_c_shape, double* gather_data,
-    bool* is_root_pe, int* ishift, int* jshift, bool* convert_cf_order);
+                                          double* array_seg, double* gather_data, bool* is_root_pe,
+                                           int* gather_data_c_shape, int* ishift, int* jshift, bool* convert_cf_order);
 
 extern void cFMS_get_compute_domain(int* domain_id, int* xbegin, int* xend, int* ybegin, int* yend,
     int* xsize, int* xmax_size, int* ysize, int* ymax_size,

--- a/c_fms/include/c_mpp_gather.inc
+++ b/c_fms/include/c_mpp_gather.inc
@@ -7,11 +7,11 @@ subroutine CFMS_GATHER_1D_(sbuf_size, sbuf, rbuf, pelist, rbuf_size, npes) &
    type(c_ptr), intent(in), value :: rbuf
    type(c_ptr), intent(in), value :: pelist
    integer, intent(in), optional :: rbuf_size
-   integer, intent(in), optional :: npes   
+   integer, intent(in), optional :: npes
 
    integer, pointer :: pelist_f(:) => NULL()
    CFMS_GATHER_TYPE_, pointer :: rbuf_f(:) => NULL()
-   
+
    if(c_associated(rbuf)) then
       if(present(rbuf_size)) then
          call c_f_pointer(rbuf, rbuf_f, [rbuf_size])
@@ -74,20 +74,34 @@ subroutine CFMS_GATHER_PELIST_2D_(is, ie, js, je, npes, pelist, array_seg, gathe
 end subroutine CFMS_GATHER_PELIST_2D_
 
 
-subroutine CFMS_GATHERV_1D_(npes, sbuf_size, rbuf_size, sbuf, ssize, rbuf, rsize, pelist) &
+subroutine CFMS_GATHERV_1D_(npes, sbuf_size, sbuf, ssize, rbuf, rsize, pelist) &
    bind(C, name=CFMS_GATHERV_1D_BINDC_)
 
    implicit none
    integer, intent(in) :: npes
    integer, intent(in) :: sbuf_size
-   integer, intent(in) :: rbuf_size
    CFMS_GATHER_TYPE_, intent(in) :: sbuf(sbuf_size)
    integer, intent(in) :: ssize
-   CFMS_GATHER_TYPE_, intent(inout) :: rbuf(rbuf_size)
-   integer, intent(in) :: rsize(npes)
+   type(c_ptr), value :: rbuf
+   type(c_ptr), value :: rsize
    integer, intent(in), optional :: pelist(npes)
 
-   call fms_mpp_gather(sbuf, ssize, rbuf, rsize, pelist)
+   CFMS_GATHER_TYPE_, pointer :: rbuf_f(:) => NULL()
+   integer, pointer :: rsize_f(:) => NULL()
+
+   if(c_associated(rsize)) then
+      call c_f_pointer(rsize, rsize_f, [npes])
+   end if
+
+   if(c_associated(rbuf)) then
+      if(.not.associated(rsize_f)) call fms_mpp_error(FATAL, "must specify receiving sizes for receiving pe")
+      call c_f_pointer(rbuf, rbuf_f, [sum(rsize_f)])
+   end if
+
+   call fms_mpp_gather(sbuf, ssize, rbuf_f, rsize_f, pelist)
+
+   nullify(rbuf_f)
+   nullify(rsize_f)
 
 end subroutine CFMS_GATHERV_1D_
 

--- a/c_fms/include/c_mpp_gather.inc
+++ b/c_fms/include/c_mpp_gather.inc
@@ -74,34 +74,42 @@ subroutine CFMS_GATHER_PELIST_2D_(is, ie, js, je, npes, pelist, array_seg, gathe
 end subroutine CFMS_GATHER_PELIST_2D_
 
 
-subroutine CFMS_GATHERV_1D_(npes, sbuf_size, sbuf, ssize, rbuf, rsize, pelist) &
+subroutine CFMS_GATHERV_1D_(sbuf_size, sbuf, ssize, rbuf, rsize, pelist, npes) &
    bind(C, name=CFMS_GATHERV_1D_BINDC_)
 
    implicit none
-   integer, intent(in) :: npes
    integer, intent(in) :: sbuf_size
    CFMS_GATHER_TYPE_, intent(in) :: sbuf(sbuf_size)
    integer, intent(in) :: ssize
-   type(c_ptr), value :: rbuf
-   type(c_ptr), value :: rsize
-   integer, intent(in), optional :: pelist(npes)
+   type(c_ptr), intent(in), value :: rbuf
+   type(c_ptr), intent(in), value :: rsize
+   type(c_ptr), intent(in), value :: pelist
+   integer, intent(in), optional :: npes
 
    CFMS_GATHER_TYPE_, pointer :: rbuf_f(:) => NULL()
    integer, pointer :: rsize_f(:) => NULL()
+   integer, pointer :: pelist_f(:) => NULL()
+   logical :: npes_defined
 
-   if(c_associated(rsize)) then
-      call c_f_pointer(rsize, rsize_f, [npes])
-   end if
-
+   npes_defined = present(npes)
+   
    if(c_associated(rbuf)) then
-      if(.not.associated(rsize_f)) call fms_mpp_error(FATAL, "must specify receiving sizes for receiving pe")
+      if(.not.c_associated(rsize)) call fms_mpp_error(FATAL, "must specify receiving sizes for receiving pe")
+      if(.not.npes_defined) call fms_mpp_error(FATAL, "must specify number of receiving/sending pe's")
+      call c_f_pointer(rsize, rsize_f, [npes])
       call c_f_pointer(rbuf, rbuf_f, [sum(rsize_f)])
    end if
 
-   call fms_mpp_gather(sbuf, ssize, rbuf_f, rsize_f, pelist)
+   if(c_associated(pelist)) then
+      if(.not.npes_defined) call fms_mpp_error(FATAL, "must specify the number of pe's when specifying pelist")
+      call c_f_pointer(pelist, pelist_f, [npes])
+   end if
+   
+   call fms_mpp_gather(sbuf, ssize, rbuf_f, rsize_f, pelist_f)
 
    nullify(rbuf_f)
    nullify(rsize_f)
+   nullify(pelist_f)
 
 end subroutine CFMS_GATHERV_1D_
 

--- a/c_fms/include/c_mpp_gather.inc
+++ b/c_fms/include/c_mpp_gather.inc
@@ -32,17 +32,17 @@ subroutine CFMS_GATHER_1D_(sbuf_size, sbuf, rbuf, pelist, rbuf_size, npes) &
 end subroutine CFMS_GATHER_1D_
 
 
-subroutine CFMS_GATHER_PELIST_2D_(is, ie, js, je, npes, pelist, array_seg, gather_data_shape, gather_data, &
-   is_root_pe, ishift, jshift, convert_cf_order) bind(C, name=CFMS_GATHER_PELIST_2D_BINDC_)
+subroutine CFMS_GATHER_PELIST_2D_(is, ie, js, je, npes, pelist, array_seg, gather_data, is_root_pe, &
+     gather_data_c_shape, ishift, jshift, convert_cf_order) bind(C, name=CFMS_GATHER_PELIST_2D_BINDC_)
 
    implicit none
    integer, intent(in) :: is, ie, js, je
    integer, intent(in) :: npes
    integer, intent(in) :: pelist(npes)
    type(c_ptr), value, intent(in) :: array_seg
-   integer, intent(in) :: gather_data_c_shape(2)
    type(c_ptr), value, intent(in) :: gather_data
    logical(c_bool), intent(in) :: is_root_pe
+   integer, intent(in), optional :: gather_data_c_shape(2)
    integer, intent(in), optional :: ishift
    integer, intent(in), optional :: jshift
    logical(c_bool), intent(in), optional :: convert_cf_order
@@ -61,8 +61,6 @@ subroutine CFMS_GATHER_PELIST_2D_(is, ie, js, je, npes, pelist, array_seg, gathe
       end if
       allocate(gather_data_f(gather_data_f_shape(1), gather_data_f_shape(2)))
       call cfms_pointer_to_array(gather_data, gather_data_f_shape, gather_data_f, convert_cf_order)
-   else
-      allocate(gather_data_f(1,1)) !dummy
    end if
 
    call fms_mpp_gather(is+1, ie+1, js+1, je+1, pelist, array_seg_f, gather_data_f, logical(is_root_pe), ishift, jshift)
@@ -71,9 +69,10 @@ subroutine CFMS_GATHER_PELIST_2D_(is, ie, js, je, npes, pelist, array_seg, gathe
       call cFMS_array_to_pointer(gather_data_f, gather_data_f_shape, gather_data, convert_cf_order)
    end if
 
-   deallocate(gather_data_f)
+   if(allocated(gather_data_f)) deallocate(gather_data_f)
 
 end subroutine CFMS_GATHER_PELIST_2D_
+
 
 subroutine CFMS_GATHERV_1D_(npes, sbuf_size, rbuf_size, sbuf, ssize, rbuf, rsize, pelist) &
    bind(C, name=CFMS_GATHERV_1D_BINDC_)

--- a/c_fms/include/c_mpp_gather.inc
+++ b/c_fms/include/c_mpp_gather.inc
@@ -1,31 +1,38 @@
-subroutine CFMS_GATHER_1D_(sbuf_size, rbuf_size, sbuf, rbuf, pelist, npes) &
+subroutine CFMS_GATHER_1D_(sbuf_size, sbuf, rbuf, pelist, rbuf_size, npes) &
    bind(C, name=CFMS_GATHER_1D_BINDC_)
 
    implicit none
    integer, intent(in) :: sbuf_size
-   integer, intent(in) :: rbuf_size
    CFMS_GATHER_TYPE_, intent(in) :: sbuf(sbuf_size)
-   CFMS_GATHER_TYPE_, intent(inout) :: rbuf(rbuf_size)
+   type(c_ptr), intent(in), value :: rbuf
    type(c_ptr), intent(in), value :: pelist
-   integer, intent(in), optional :: npes
+   integer, intent(in), optional :: rbuf_size
+   integer, intent(in), optional :: npes   
 
    integer, pointer :: pelist_f(:) => NULL()
+   CFMS_GATHER_TYPE_, pointer :: rbuf_f(:) => NULL()
+   
+   if(c_associated(rbuf)) then
+      if(present(rbuf_size)) then
+         call c_f_pointer(rbuf, rbuf_f, [rbuf_size])
+      end if
+   end if
 
-   if(present(npes)) then
-      if(c_associated(pelist)) then
-         allocate(pelist_f(npes))
+   if(c_associated(pelist)) then
+      if(present(npes)) then
          call c_f_pointer(pelist, pelist_f, [npes])
       end if
    end if
 
-   call fms_mpp_gather(sbuf, rbuf, pelist=pelist_f)
+   call fms_mpp_gather(sbuf, rbuf_f, pelist=pelist_f)
 
    nullify(pelist_f)
+   nullify(rbuf_f)
 
 end subroutine CFMS_GATHER_1D_
 
 
-subroutine CFMS_GATHER_PELIST_2D_(is, ie, js, je, npes, pelist, array_seg, gather_data_c_shape, gather_data, &
+subroutine CFMS_GATHER_PELIST_2D_(is, ie, js, je, npes, pelist, array_seg, gather_data_shape, gather_data, &
    is_root_pe, ishift, jshift, convert_cf_order) bind(C, name=CFMS_GATHER_PELIST_2D_BINDC_)
 
    implicit none

--- a/test_cfms/c_fms/test_gather.c
+++ b/test_cfms/c_fms/test_gather.c
@@ -161,7 +161,7 @@ void test_1d_v() {
     rbuf = (CFMS_TEST_KIND_*)malloc(rbuf_size * sizeof(CFMS_TEST_KIND_));
   }
 
-  CFMS_GATHERV_1D_(&npes, &ssize, sbuf, &ssize, rbuf, rsize, NULL);
+  CFMS_GATHERV_1D_(&ssize, sbuf, &ssize, rbuf, rsize, NULL, &npes);
 
   CFMS_TEST_KIND_* answers;
   for (int i = 0; i < rbuf_size; i++) {
@@ -209,11 +209,11 @@ void test_1d_v_pelist() {
   int rsize[2] = { nsize, nsize };
   int rbuf_size = nsize * 2;
 
-  CFMS_TEST_KIND_* rbuf;
+  CFMS_TEST_KIND_* rbuf = NULL;
   if (pe == cFMS_root_pe())
     rbuf = (CFMS_TEST_KIND_*)malloc(rbuf_size * sizeof(CFMS_TEST_KIND_));
 
-  CFMS_GATHERV_1D_(&npes, &ssize, sbuf, &ssize, rbuf, rsize, pelist);
+  CFMS_GATHERV_1D_(&ssize, sbuf, &ssize, rbuf, rsize, pelist, &npes);
 
   CFMS_TEST_KIND_* answers;
   answers = (CFMS_TEST_KIND_*)malloc(rbuf_size * sizeof(CFMS_TEST_KIND_));

--- a/test_cfms/c_fms/test_gather.c
+++ b/test_cfms/c_fms/test_gather.c
@@ -36,11 +36,11 @@ int main() {
     printf("testing cFMS_gather_1d %d\n", sizeof(kind));
     test_1d();
 
-    printf("testing cFMS_gather_2d_pelist %d\n", sizeof(kind));
-    test_2d(domain_id);
+    /* printf("testing cFMS_gather_2d_pelist %d\n", sizeof(kind)); */
+    /* test_2d(domain_id); */
 
-    printf("testing cFMS_gather_v_1d %d\n", sizeof(kind));
-    test_1d_v();
+    /* printf("testing cFMS_gather_v_1d %d\n", sizeof(kind)); */
+    /* test_1d_v(); */
 
     cFMS_end();
     return EXIT_SUCCESS;
@@ -103,7 +103,7 @@ void test_1d() {
     int sbuf_size = 4;
     int rbuf_size = sbuf_size * cFMS_npes();
     int pe = cFMS_pe();
-    CFMS_TEST_KIND_* sbuf, * rbuf;
+    CFMS_TEST_KIND_* sbuf=NULL, * rbuf=NULL;
 
     bool is_root_pe = pe == cFMS_root_pe() ? true : false;
 
@@ -118,7 +118,7 @@ void test_1d() {
         rbuf = (CFMS_TEST_KIND_*)calloc(rbuf_size, sizeof(CFMS_TEST_KIND_));
     }
 
-    CFMS_GATHER_1D_(&sbuf_size, &rbuf_size, sbuf, rbuf, NULL, NULL);
+    CFMS_GATHER_1D_(&sbuf_size, sbuf, rbuf, NULL, &rbuf_size, NULL);
 
     //check answers
     if (is_root_pe) {
@@ -130,6 +130,10 @@ void test_1d() {
             }
         }
     }
+
+    printf("herehere\n");
+    free(sbuf);
+    free(rbuf);
 
 }
 

--- a/test_cfms/c_fms/test_gather.c
+++ b/test_cfms/c_fms/test_gather.c
@@ -32,12 +32,11 @@ int main() {
     // set domain
     int domain_id = cFMS_define_domains_easy(domain);
 
-
     printf("testing cFMS_gather_1d %d\n", sizeof(kind));
     test_1d();
 
-    /* printf("testing cFMS_gather_2d_pelist %d\n", sizeof(kind)); */
-    /* test_2d(domain_id); */
+    printf("testing cFMS_gather_2d_pelist %d\n", sizeof(kind));
+    test_2d(domain_id);
 
     /* printf("testing cFMS_gather_v_1d %d\n", sizeof(kind)); */
     /* test_1d_v(); */
@@ -75,17 +74,16 @@ void test_2d(int domain_id) {
 
     // set data to receive
     CFMS_TEST_KIND_* gather;
-    int gather_shape[2] = { 1, 1 };
+    int *gather_shape = NULL;
     if (is_root_pe) {
-        gather_shape[0] = NX;
-        gather_shape[1] = NY;
-        gather = (CFMS_TEST_KIND_*)calloc(NX * NY, sizeof(CFMS_TEST_KIND_));
+      gather_shape = (int *)malloc(2*sizeof(int));
+      gather_shape[0] = NX;
+      gather_shape[1] = NY;
+      gather = (CFMS_TEST_KIND_*)calloc(NX * NY, sizeof(CFMS_TEST_KIND_));
     }
-    else
-        gather = (CFMS_TEST_KIND_*)malloc(1 * sizeof(CFMS_TEST_KIND_));
 
     CFMS_GATHER_PELIST_2D_(&isc, &iec, &jsc, &jec, &ndivs, pelist,
-        send, gather_shape, gather, &is_root_pe, NULL, NULL, NULL);
+                           send, gather, &is_root_pe, gather_shape, NULL, NULL, NULL);
 
     if (is_root_pe) {
         int ij = 0;

--- a/test_cfms/c_fms/test_gather.c
+++ b/test_cfms/c_fms/test_gather.c
@@ -10,171 +10,231 @@
 void test_2d(int domain_id);
 void test_1d();
 void test_1d_v();
+void test_1d_v_pelist();
 
 int main() {
 
-    int* global_pelist = NULL;
-    int global_indices[4] = { 0, NX - 1, 0, NY - 1 };
-    CFMS_TEST_KIND_ kind;
-    cDomainStruct domain;
+  int* global_pelist = NULL;
+  int global_indices[4] = { 0, NX - 1, 0, NY - 1 };
+  CFMS_TEST_KIND_ kind;
+  cDomainStruct domain;
 
-    cFMS_init(NULL, NULL, NULL, NULL, NULL);
-    cFMS_null_cdomain(&domain);
+  cFMS_init(NULL, NULL, NULL, NULL, NULL);
+  cFMS_null_cdomain(&domain);
 
-    // set domain fields to use the easy domain method
-    int ndivs = cFMS_npes();
-    domain.layout = (int*)malloc(2 * sizeof(int));
-    domain.global_indices = global_indices;
+  // set domain fields to use the easy domain method
+  int ndivs = cFMS_npes();
+  domain.layout = (int*)malloc(2 * sizeof(int));
+  domain.global_indices = global_indices;
 
-    // set layout
-    cFMS_define_layout(global_indices, &ndivs, domain.layout);
+  // set layout
+  cFMS_define_layout(global_indices, &ndivs, domain.layout);
 
-    // set domain
-    int domain_id = cFMS_define_domains_easy(domain);
+  // set domain
+  int domain_id = cFMS_define_domains_easy(domain);
 
-    printf("testing cFMS_gather_1d %d\n", sizeof(kind));
-    test_1d();
+  printf("testing cFMS_gather_1d %d\n", sizeof(kind));
+  test_1d();
 
-    printf("testing cFMS_gather_2d_pelist %d\n", sizeof(kind));
-    test_2d(domain_id);
+  printf("testing cFMS_gather_2d_pelist %d\n", sizeof(kind));
+  test_2d(domain_id);
 
-    /* printf("testing cFMS_gather_v_1d %d\n", sizeof(kind)); */
-    /* test_1d_v(); */
+  printf("testing cFMS_gatherv_1d %d\n", sizeof(kind));
+  test_1d_v();
 
-    cFMS_end();
-    return EXIT_SUCCESS;
+  printf("testing cFMS_gatherv_1d with pelist %d\n", sizeof(kind));
+  test_1d_v_pelist();
+
+  cFMS_end();
+  return EXIT_SUCCESS;
 
 }
 
 void test_2d(int domain_id) {
-    // get pe
-    int pe = cFMS_pe();
-    int root_pe = cFMS_root_pe();
-    bool is_root_pe = pe == root_pe ? true : false;
+  // get pe
+  int pe = cFMS_pe();
+  int root_pe = cFMS_root_pe();
+  bool is_root_pe = pe == root_pe ? true : false;
 
-    // get pelist
-    int ndivs = cFMS_npes();
-    int pelist[4] = { 0, 0, 0, 0 };
-    cFMS_get_domain_pelist(&ndivs, pelist, &domain_id);
+  // get pelist
+  int ndivs = cFMS_npes();
+  int pelist[4] = { 0, 0, 0, 0 };
+  cFMS_get_domain_pelist(&ndivs, pelist, &domain_id);
 
-    // get compute domain
-    int isc, iec, jsc, jec, xsize, ysize;
-    cFMS_get_compute_domain(&domain_id, &isc, &iec, &jsc, &jec,
-        &xsize, NULL, &ysize, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+  // get compute domain
+  int isc, iec, jsc, jec, xsize, ysize;
+  cFMS_get_compute_domain(&domain_id, &isc, &iec, &jsc, &jec,
+    &xsize, NULL, &ysize, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
-    // set data to send
+  // set data to send
+  int ij = 0;
+  CFMS_TEST_KIND_* send;
+  send = (CFMS_TEST_KIND_*)malloc(xsize * ysize * sizeof(CFMS_TEST_KIND_));
+  for (int i = 0; i < xsize; i++) {
+    for (int j = 0; j < ysize; j++) {
+      send[ij++] = (CFMS_TEST_KIND_)((isc + i) * 100 + j + jsc);
+    }
+  }
+
+  // set data to receive
+  CFMS_TEST_KIND_* gather;
+  int* gather_shape = NULL;
+  if (is_root_pe) {
+    gather_shape = (int*)malloc(2 * sizeof(int));
+    gather_shape[0] = NX;
+    gather_shape[1] = NY;
+    gather = (CFMS_TEST_KIND_*)calloc(NX * NY, sizeof(CFMS_TEST_KIND_));
+  }
+
+  CFMS_GATHER_PELIST_2D_(&isc, &iec, &jsc, &jec, &ndivs, pelist,
+    send, gather, &is_root_pe, gather_shape, NULL, NULL, NULL);
+
+  if (is_root_pe) {
     int ij = 0;
-    CFMS_TEST_KIND_* send;
-    send = (CFMS_TEST_KIND_*)malloc(xsize * ysize * sizeof(CFMS_TEST_KIND_));
-    for (int i = 0; i < xsize; i++) {
-        for (int j = 0; j < ysize; j++) {
-            send[ij++] = (CFMS_TEST_KIND_)((isc + i) * 100 + j + jsc);
-        }
+    for (int i = 0; i < NX; i++) {
+      for (int j = 0; j < NY; j++) {
+        if (gather[ij++] != (CFMS_TEST_KIND_)(i * 100 + j))
+          cFMS_error(FATAL, "error testing cFMS_gather_pelist");
+      }
     }
-
-    // set data to receive
-    CFMS_TEST_KIND_* gather;
-    int *gather_shape = NULL;
-    if (is_root_pe) {
-      gather_shape = (int *)malloc(2*sizeof(int));
-      gather_shape[0] = NX;
-      gather_shape[1] = NY;
-      gather = (CFMS_TEST_KIND_*)calloc(NX * NY, sizeof(CFMS_TEST_KIND_));
-    }
-
-    CFMS_GATHER_PELIST_2D_(&isc, &iec, &jsc, &jec, &ndivs, pelist,
-                           send, gather, &is_root_pe, gather_shape, NULL, NULL, NULL);
-
-    if (is_root_pe) {
-        int ij = 0;
-        for (int i = 0; i < NX; i++) {
-            for (int j = 0; j < NY; j++) {
-                if (gather[ij++] != (CFMS_TEST_KIND_)(i * 100 + j))
-                    cFMS_error(FATAL, "error testing cFMS_gather_pelist");
-            }
-        }
-    }
+  }
 }
 
 void test_1d() {
 
-    int sbuf_size = 4;
-    int rbuf_size = sbuf_size * cFMS_npes();
-    int pe = cFMS_pe();
-    CFMS_TEST_KIND_* sbuf=NULL, * rbuf=NULL;
+  int sbuf_size = 4;
+  int rbuf_size = sbuf_size * cFMS_npes();
+  int pe = cFMS_pe();
+  CFMS_TEST_KIND_* sbuf = NULL, * rbuf = NULL;
 
-    bool is_root_pe = pe == cFMS_root_pe() ? true : false;
+  bool is_root_pe = pe == cFMS_root_pe() ? true : false;
 
-    //set data
-    sbuf = (CFMS_TEST_KIND_*)malloc(sbuf_size * sizeof(CFMS_TEST_KIND_));
-    for (int i = 0; i < sbuf_size; i++) {
-        sbuf[i] = (CFMS_TEST_KIND_)(pe * 10 + i);
+  //set data
+  sbuf = (CFMS_TEST_KIND_*)malloc(sbuf_size * sizeof(CFMS_TEST_KIND_));
+  for (int i = 0; i < sbuf_size; i++) {
+    sbuf[i] = (CFMS_TEST_KIND_)(pe * 10 + i);
+  }
+
+  //set receive data;
+  if (is_root_pe) {
+    rbuf = (CFMS_TEST_KIND_*)calloc(rbuf_size, sizeof(CFMS_TEST_KIND_));
+  }
+
+  CFMS_GATHER_1D_(&sbuf_size, sbuf, rbuf, NULL, &rbuf_size, NULL);
+
+  //check answers
+  if (is_root_pe) {
+    int ij = 0;
+    for (int p = 0; p < cFMS_npes(); p++) {
+      for (int i = 0; i < sbuf_size; i++) {
+        if (rbuf[ij++] != (CFMS_TEST_KIND_)(p * 10 + i))
+          cFMS_error(FATAL, "error testing cFMS_gather_1d_cCFMS_GATHER_TYPE_");
+      }
     }
+  }
 
-    //set receive data;
-    if (is_root_pe) {
-        rbuf = (CFMS_TEST_KIND_*)calloc(rbuf_size, sizeof(CFMS_TEST_KIND_));
-    }
-
-    CFMS_GATHER_1D_(&sbuf_size, sbuf, rbuf, NULL, &rbuf_size, NULL);
-
-    //check answers
-    if (is_root_pe) {
-        int ij = 0;
-        for (int p = 0; p < cFMS_npes(); p++) {
-            for (int i = 0; i < sbuf_size; i++) {
-                if (rbuf[ij++] != (CFMS_TEST_KIND_)(p * 10 + i))
-                    cFMS_error(FATAL, "error testing cFMS_gather_1d_cCFMS_GATHER_TYPE_");
-            }
-        }
-    }
-
-    printf("herehere\n");
-    free(sbuf);
-    free(rbuf);
+  free(sbuf);
+  free(rbuf);
 
 }
 
 void test_1d_v() {
 
-    int npes = cFMS_npes();
-    int pe = cFMS_pe();
-    int ssize = pe + 1;
+  int npes = cFMS_npes();
+  int pe = cFMS_pe();
+  int ssize = pe + 1;
 
-    CFMS_TEST_KIND_* sbuf;
-    sbuf = (CFMS_TEST_KIND_*)malloc(ssize * sizeof(CFMS_TEST_KIND_));
-    for (int i = 0; i < ssize; i++) {
-        sbuf[i] = (CFMS_TEST_KIND_)(pe * 10 + i);
-    }
+  CFMS_TEST_KIND_* sbuf;
+  sbuf = (CFMS_TEST_KIND_*)malloc(ssize * sizeof(CFMS_TEST_KIND_));
+  for (int i = 0; i < ssize; i++) {
+    sbuf[i] = (CFMS_TEST_KIND_)(pe * 10 + i);
+  }
 
-    int* rsize, rbuf_size = 0;
+  CFMS_TEST_KIND_* rbuf = NULL;
+  int* rsize = NULL, rbuf_size = 0;
+  if (pe == cFMS_root_pe()) {
     rsize = (int*)malloc(npes * sizeof(int));
     for (int p = 0; p < npes; p++) {
-        rsize[p] = p + 1;
-        rbuf_size += rsize[p];
+      rsize[p] = p + 1;
+      rbuf_size += rsize[p];
     }
+    rbuf = (CFMS_TEST_KIND_*)malloc(rbuf_size * sizeof(CFMS_TEST_KIND_));
+  }
 
-    CFMS_TEST_KIND_* rbuf;
-    if (pe == cFMS_root_pe())
-        rbuf = (CFMS_TEST_KIND_*)malloc(rbuf_size * sizeof(CFMS_TEST_KIND_));
+  CFMS_GATHERV_1D_(&npes, &ssize, sbuf, &ssize, rbuf, rsize, NULL);
 
-    CFMS_GATHERV_1D_(&npes, &ssize, &rbuf_size, sbuf, &ssize, rbuf, rsize, NULL);
+  CFMS_TEST_KIND_* answers;
+  for (int i = 0; i < rbuf_size; i++) {
+    answers = (CFMS_TEST_KIND_*)malloc(rbuf_size * sizeof(CFMS_TEST_KIND_));
+    int ij = 0;
+    for (int p = 0; p < npes; p++) {
+      for (int j = 0; j < p + 1; j++) {
+        answers[ij++] = (CFMS_TEST_KIND_)(p * 10 + j);
+      }
+    }
+  }
 
-    CFMS_TEST_KIND_* answers;
+  if (pe == cFMS_root_pe()) {
     for (int i = 0; i < rbuf_size; i++) {
-        answers = (CFMS_TEST_KIND_*)malloc(rbuf_size * sizeof(CFMS_TEST_KIND_));
-        int ij = 0;
-        for (int p = 0; p < npes; p++) {
-            for (int j = 0; j < p + 1; j++) {
-                answers[ij++] = (CFMS_TEST_KIND_)(p * 10 + j);
-            }
-        }
+      if (rbuf[i] != answers[i])
+        cFMS_error(FATAL, "error testing cFMS_gather_v_1d_cCFMS_GATHER_TYPE_");
     }
+  }
 
-    if (pe == cFMS_root_pe()) {
-        for (int i = 0; i < rbuf_size; i++) {
-            if (rbuf[i] != answers[i])
-                cFMS_error(FATAL, "error testing cFMS_gather_v_1d_cCFMS_GATHER_TYPE_");
-        }
-    }
+  free(rbuf);
+  free(sbuf);
+  free(rsize);
+
 }
+
+void test_1d_v_pelist() {
+
+  int npes = 2;
+  int nsize = 5;
+  int pe = cFMS_pe();
+  int ssize = 1;
+  int* pelist = NULL;
+
+  if (pe == 0 || pe == 1) {
+    ssize = nsize;
+    pelist = (int*)malloc(2 * sizeof(int));
+    for (int i = 0; i < 2; i++) pelist[i] = i;
+  }
+
+  CFMS_TEST_KIND_* sbuf; sbuf = (CFMS_TEST_KIND_*)malloc(ssize * sizeof(CFMS_TEST_KIND_));
+  for (int i = 0; i < ssize; i++) {
+    sbuf[i] = (CFMS_TEST_KIND_)(pe * 10 + i);
+  }
+
+  int rsize[2] = { nsize, nsize };
+  int rbuf_size = nsize * 2;
+
+  CFMS_TEST_KIND_* rbuf;
+  if (pe == cFMS_root_pe())
+    rbuf = (CFMS_TEST_KIND_*)malloc(rbuf_size * sizeof(CFMS_TEST_KIND_));
+
+  CFMS_GATHERV_1D_(&npes, &ssize, sbuf, &ssize, rbuf, rsize, pelist);
+
+  CFMS_TEST_KIND_* answers;
+  answers = (CFMS_TEST_KIND_*)malloc(rbuf_size * sizeof(CFMS_TEST_KIND_));
+  int ij = 0;
+  for (int p = 0; p < 2; p++) {
+    for (int j = 0; j < nsize; j++) {
+      answers[ij++] = (CFMS_TEST_KIND_)(p * 10 + j);
+    }
+  }
+
+  if (pe == cFMS_root_pe()) {
+    for (int i = 0; i < rbuf_size; i++) {
+      if (rbuf[i] != answers[i])
+        cFMS_error(FATAL, "error testing cFMS_gather_v_1d_cCFMS_GATHER_TYPE_");
+    }
+  }
+
+  free(sbuf);
+  free(answers);
+
+}
+
+
+


### PR DESCRIPTION
This PR

1.  brings in the latest FMS that does not require the array `rbuf` to be allocated for non-receiving pe's.
2.  cleans up the subroutines
3.  adds an additional gatherv test with a user-defined pelist