### PR TITLE
fix mpi issues with register diag field routines

### DIFF
--- a/c_diag_manager/c_diag_manager.F90
+++ b/c_diag_manager/c_diag_manager.F90
@@ -7,14 +7,14 @@ module c_diag_manager_mod
 
   use fms_diag_yaml_mod, only: get_num_unique_fields
 
-  use FMS, only : fms_string_utils_c2f_string, fms_string_utils_f2c_string  
-  
+  use FMS, only : fms_string_utils_c2f_string, fms_string_utils_f2c_string
+
   use FMS, only : FmsTime_type, Operator(+)
   use FMS, only : fms_time_manager_set_date, fms_time_manager_set_time
 
   use FMS, only : fms_mpp_error, FATAL
   use FMS, only : fms_time_manager_get_date
-  
+
   use FMS, only : FmsMppDomain2D
 
   use c_fms_mod, only : cFMS_get_domain
@@ -22,28 +22,25 @@ module c_diag_manager_mod
   use c_fms_utils_mod, only : cFMS_pointer_to_array
 
   use iso_c_binding
-  
+
   implicit none
 
   private
-  
+
   public :: cFMS_diag_axis_init_cfloat
-  public :: cFMS_diag_axis_init_cdouble  
+  public :: cFMS_diag_axis_init_cdouble
   public :: cFMS_diag_end
   public :: cFMS_diag_send_complete
   public :: cFMS_diag_init
   public :: cFMS_diag_set_time_end
-  public :: cFMS_diag_set_field_init_time
-  public :: cFMS_diag_set_field_timestep
-  public :: cFMS_diag_advance_field_time
-  
+
   public :: cFMS_register_diag_field_scalar_cint
   public :: cFMS_register_diag_field_scalar_cfloat
   public :: cFMS_register_diag_field_scalar_cdouble
   public :: cFMS_register_diag_field_array_cint
   public :: cFMS_register_diag_field_array_cfloat
   public :: cFMS_register_diag_field_array_cdouble
-  
+
   public :: cFMS_diag_send_data_2d_cint
   public :: cFMS_diag_send_data_3d_cint
   public :: cFMS_diag_send_data_4d_cint
@@ -54,30 +51,26 @@ module c_diag_manager_mod
   public :: cFMS_diag_send_data_3d_cdouble
   public :: cFMS_diag_send_data_4d_cdouble
 
-  public :: c_diag_manager_is_initialized
-  
-  type(FmsTime_type) :: field_init_time
-  type(FmsTime_type) :: cFMS_diag_end_time
-  type(FmsTime_type), allocatable :: field_curr_time(:)
-  type(FmsTime_type), allocatable :: field_timestep(:)
-  
   integer, public, bind(C, name="DIAG_OTHER") :: DIAG_OTHER_C = DIAG_OTHER
   integer, public, bind(C, name="DIAG_OCEAN") :: DIAG_OCEAN_C = DIAG_OCEAN
   integer, public, bind(C, name="DIAG_ALL")   :: DIAG_ALL_C   = DIAG_ALL
 
-  logical :: module_is_initialized = .false.
-  
 contains
 
-  subroutine cFMS_diag_end() bind(C, name="cFMS_diag_end")
+  subroutine cFMS_diag_end(time_end) bind(C, name="cFMS_diag_end")
     implicit none
+    integer, intent(in) :: time_end(7) !< year, month, date, hours, minutes, seconds, ticks
+    type(FmsTime_type) :: model_end_time
 
-    call fms_diag_end(cFMS_diag_end_time)
-    if(allocated(field_curr_time)) deallocate(field_curr_time)
-    if(allocated(field_timestep)) deallocate(field_timestep)
+    model_end_time = fms_time_manager_set_date(year = time_end(1),   &
+                                         month= time_end(2),   &
+                                         day = time_end(3),    &
+                                         hour = time_end(4),   &
+                                         minute = time_end(5), &
+                                         second = time_end(6), &
+                                         tick = time_end(7))
+    call fms_diag_end(model_end_time)
 
-    module_is_initialized = .false.
-    
   end subroutine cFMS_diag_end
 
   !cFMS_diag_init
@@ -88,165 +81,65 @@ contains
     integer, intent(in), optional :: time_init(6)
     character(c_char), intent(out), optional :: err_msg(MESSAGE_LENGTH)
 
-    integer :: nfields    
     character(len=MESSAGE_LENGTH-1) :: err_msg_f = "None"
-    
+
     call fms_diag_init(diag_model_subset = diag_model_subset, &
                        time_init = time_init, &
                        err_msg = err_msg_f)
 
-    if(module_is_initialized) return
-    
-    nfields = get_num_unique_fields()
-    allocate(field_curr_time(nfields))
-    allocate(field_timestep(nfields))
+    if(present(err_msg) .and. err_msg_f /= '' ) call fms_string_utils_f2c_string(err_msg, err_msg_f)
+
+  end subroutine cFMS_diag_init
+
+  !cFMS_diag_send_complete
+  subroutine cFMS_diag_send_complete(timestep, err_msg) bind(C, name="cFMS_diag_send_complete")
+
+    implicit none
+    integer, intent(in) :: timestep(7)
+    character(c_char), intent(out), optional :: err_msg(MESSAGE_LENGTH)
+    type(FmsTime_type) :: time
+
+    character(len=MESSAGE_LENGTH-1) :: err_msg_f = "None"
+
+    time = fms_time_manager_set_date(year=timestep(1),   &
+                                           month=timestep(2),  &
+                                           day=timestep(3),    &
+                                           hour=timestep(4),   &
+                                           minute=timestep(5), &
+                                           second=timestep(6), &
+                                           tick=timestep(7))
+    call fms_diag_send_complete(time, err_msg_f)
 
     if(present(err_msg) .and. err_msg_f /= '' ) call fms_string_utils_f2c_string(err_msg, err_msg_f)
 
-    module_is_initialized = .true.
-    
-  end subroutine cFMS_diag_init
-
-  !c_diag_manager_is_initialized
-  function c_diag_manager_is_initialized() bind(C, name="c_diag_manager_is_initialized")
-
-    implicit none
-    logical(c_bool) :: c_diag_manager_is_initialized
-
-    c_diag_manager_is_initialized = logical(module_is_initialized, kind=c_bool)
-    
-  end function c_diag_manager_is_initialized
-
-  !cFMS_diag_send_complete
-  subroutine cFMS_diag_send_complete(diag_field_id, err_msg) bind(C, name="cFMS_diag_send_complete")
-
-    implicit none
-    integer, intent(in) :: diag_field_id
-    character(c_char), intent(out), optional :: err_msg(MESSAGE_LENGTH)
-
-    character(len=MESSAGE_LENGTH-1) :: err_msg_f = "None"
-    
-    call fms_diag_send_complete(field_timestep(diag_field_id), err_msg_f)
-
-    if(present(err_msg) .and. err_msg_f /= '' ) call fms_string_utils_f2c_string(err_msg, err_msg_f) 
-    
   end subroutine cFMS_diag_send_complete
-  
 
-  !cFMS_diag_set_field_init_time
-  subroutine cFMS_diag_set_field_init_time(year, month, day, hour, minute, second, tick, err_msg) &
-       bind(C, name="cFMS_diag_set_field_init_time")
-
-    implicit none
-    integer, intent(in) :: year
-    integer, intent(in) :: month
-    integer, intent(in) :: day
-    integer, intent(in) :: hour
-    integer, intent(in) :: minute
-    integer, intent(in), optional :: second
-    integer, intent(in), optional :: tick
-    character, intent(out), optional :: err_msg(MESSAGE_LENGTH)
-
-    character(MESSAGE_LENGTH-1) :: err_msg_f = ""
-    
-    field_init_time = fms_time_manager_set_date(year = year,     &
-                                                month = month,   &
-                                                day = day,       &
-                                                hour = hour,     &
-                                                minute = minute, &
-                                                second = second, &
-                                                tick = tick,     &
-                                                err_msg = err_msg_f)
-
-    if(present(err_msg) .and. err_msg_f /= '') call fms_string_utils_f2c_string(err_msg, err_msg_f)
-    
-  end subroutine cFMS_diag_set_field_init_time
-
-
-  !cFMS_diag_set_field_timestep
-  subroutine cFMS_diag_set_field_timestep(diag_field_id, dseconds, ddays, dticks, &
-       err_msg) bind(C, name="cFMS_diag_set_field_timestep")
-
-    implicit none
-    integer, intent(in) :: diag_field_id
-    integer, intent(in) :: dseconds
-    integer, intent(in), optional :: ddays
-    integer, intent(in), optional :: dticks
-    character, intent(out), optional :: err_msg(MESSAGE_LENGTH)
-
-    character(MESSAGE_LENGTH-1) :: err_msg_f = ""
-
-    field_timestep(diag_field_id) = fms_time_manager_set_time(seconds = dseconds, &
-                                                              days = ddays,       &         
-                                                              ticks = dticks,     &
-                                                              err_msg = err_msg_f)    
-    
-    if(present(err_msg) .and. err_msg_f /= '') call fms_string_utils_f2c_string(err_msg, err_msg_f)
-    
-  end subroutine cFMS_diag_set_field_timestep
-
-  
-  !cFMS_diag_advance_field_time
-  subroutine cFMS_diag_advance_field_time(diag_field_id) bind(C, name="cFMS_diag_advance_field_time")
-    
-    implicit none
-    integer, intent(in) :: diag_field_id
-
-    integer :: year, month, day, hour, minute, second
-    
-    field_curr_time(diag_field_id) = field_curr_time(diag_field_id) + field_timestep(diag_field_id)
-
-    
-  end subroutine cFMS_diag_advance_field_time
-
-  subroutine cFMS_diag_set_time_end(year, month, day, hour, minute, second, tick, err_msg) &
+  subroutine cFMS_diag_set_time_end(time_end, err_msg) &
        bind(C, name="cFMS_diag_set_time_end")
 
     implicit none
-    integer, intent(in), optional :: year
-    integer, intent(in), optional :: month
-    integer, intent(in), optional :: day
-    integer, intent(in), optional :: hour
-    integer, intent(in), optional :: minute
-    integer, intent(in), optional :: second
-    integer, intent(in), optional :: tick
+    integer, intent(in), optional :: time_end(7)
     character(c_char), intent(in), optional :: err_msg(MESSAGE_LENGTH)
 
     character(MESSAGE_LENGTH-1) :: err_msg_f
+    type(FmsTime_type) :: time
 
-    cFMS_diag_end_time = fms_time_manager_set_date(year = year,     &
-                                                   month = month,   &
-                                                   day = day,       &
-                                                   hour = hour,     &
-                                                   minute = minute, &
-                                                   second = second, &
-                                                   tick = tick,     &
+    time = fms_time_manager_set_date(year = time_end(1),     &
+                                                   month = time_end(2),   &
+                                                   day = time_end(3),       &
+                                                   hour = time_end(4),     &
+                                                   minute = time_end(5), &
+                                                   second = time_end(6), &
+                                                   tick = time_end(7),     &
                                                    err_msg = err_msg_f)
 
-    call fms_diag_set_time_end(cFMS_diag_end_time)
-    
+    call fms_diag_set_time_end(time)
+
   end subroutine cFMS_diag_set_time_end
-  
+
+
 #include "c_diag_axis_init.fh"
 #include "c_register_diag_field.fh"
-#include "c_send_data.fh"  
-  
-  !subroutine register_diag_field
-  !subroutine register_static_field
-  
-  
-  !subroutine send_data
-  !subroutine send_tile_averaged_data
-  !subroutine diag_end
-  !subroutine get_base_time
-  !subroutine get_base_date
-  !subroutine get_diag_global_att
-  !subroutine set_diag_global_att
-  !subroutine diag_field_add_attribute
-  !subroutine get_diag_field_id
-  !subroutine diag_axis_add_attribute
-  !subroutine diag_send_complete
-  !subroutine diag_send_complete_instant
-  
-  
+#include "c_send_data.fh"
+
 end module c_diag_manager_mod

--- a/c_diag_manager/c_diag_manager.h
+++ b/c_diag_manager/c_diag_manager.h
@@ -17,66 +17,58 @@ extern int cFMS_diag_axis_init_cdouble(char *name, int *naxis_data, double *axis
                                        int *domain_id, char *long_name, int *direction, char *set_name, int *edges,
                                        char *aux, char *req, int *tile_count, int *domain_position, bool *not_xy);
 
-extern void cFMS_diag_end();
+extern void cFMS_diag_end(int *time_end);
 
 extern bool c_diag_manager_is_initialized();
 
-extern void cFMS_diag_send_complete(int *diag_field_id, char *err_msg);
+extern void cFMS_diag_set_time_end(int* time_end, char* err_msg);
 
-extern void cFMS_diag_set_field_init_time(int *year, int *month, int *day, int *hour, int *minute, int *second,
-                                          int *tick, char *err_msg);
-
-extern void cFMS_diag_set_field_timestep(int *diag_field_id, int *dseconds, int *ddays, int *dticks, char *err_msg);
-
-extern void cFMS_diag_advance_field_time(int *diag_field_id);
-
-extern void cFMS_diag_set_time_end(int *year, int *month, int *day, int *hour, int *minute, int *second,
-                                   int *tick, char *err_msg);
+extern void cFMS_diag_send_complete(int *timestep, char *err_msg);
 
 extern int cFMS_register_diag_field_scalar_int(char *module_name, char *field_name, char *long_name,
-                                               char *units, int *missing_value, int *range,
+                                               char *units, int* time, int *missing_value, int *range,
                                                char *standard_name, bool *do_not_log, char *err_msg,
                                                int *area, int *volume, char *realm, bool *multiple_send_data);
 
 extern int cFMS_register_diag_field_scalar_cfloat(char *module_name, char *field_name, char *long_name,
-                                                  char *units, float *missing_value, float *range,
+                                                  char *units, int* time, float *missing_value, float *range,
                                                   char *standard_name, bool *do_not_log, char *err_msg,
                                                   int *area, int *volume, char *realm, bool *multiple_send_data);
 
 extern int cFMS_register_diag_field_scalar_cdouble(char *module_name, char *field_name, char *long_name,
-                                                   char *units, double *missing_value, double *range,
+                                                   char *units, int* time, double *missing_value, double *range,
                                                    char *standard_name, bool *do_not_log, char *err_msg,
                                                    int *area, int *volume, char *realm, bool *multiple_send_data);
 
 extern int cFMS_register_diag_field_array_cint(char *module_name, char *field_name, int *axes, char *long_name,
-                                               char *units, int *missing_value, int *range, bool *mask_variant,
+                                               char *units, int* time, int *missing_value, int *range, bool *mask_variant,
                                                char *standard_name, bool *verbose, bool *do_not_log, char *err_msg,
                                                char *interp_method, int *tile_count, int *area, int *volume,
                                                char *realm, bool *multiple_send_data);
 
 extern int cFMS_register_diag_field_array_cfloat(char *module_name, char *field_name, int *axes, char *long_name,
-                                                 char *units, float *missing_value, float *range, bool *mask_variant,
+                                                 char *units, int* time, float *missing_value, float *range, bool *mask_variant,
                                                  char *standard_name, bool *verbose, bool *do_not_log, char *err_msg,
                                                  char *interp_method, int *tile_count, int *area, int *volume,
                                                  char *realm, bool *multiple_send_data);
 
 extern int cFMS_register_diag_field_array_cdouble(char *module_name, char *field_name, int *axes, char *long_name,
-                                                  char *units, double *missing_value, double *range, bool *mask_variant,
+                                                  char *units, int* time, double *missing_value, double *range, bool *mask_variant,
                                                   char *standard_name, bool *verbose, bool *do_not_log, char *err_msg,
                                                   char *interp_method, int *tile_count, int *area, int *volume,
-                                                  char *realm, bool *multiple_send_data);                                                 
+                                                  char *realm, bool *multiple_send_data);
 
-extern bool cFMS_diag_send_data_2d_cint(int *diag_field_id, int *field_shape, int *field, char *err_msg, bool *convert_cf_data);
-extern bool cFMS_diag_send_data_3d_cint(int *diag_field_id, int *field_shape, int *field, char *err_msg, bool *convert_cf_data);
-extern bool cFMS_diag_send_data_4d_cint(int *diag_field_id, int *field_shape, int *field, char *err_msg, bool *convert_cf_data);
-extern bool cFMS_diag_send_data_5d_cint(int *diag_field_id, int *field_shape, int *field, char *err_msg, bool *convert_cf_data);
-extern bool cFMS_diag_send_data_2d_cfloat(int *diag_field_id, int *field_shape, float *field, char *err_msg, bool *convert_cf_data);
-extern bool cFMS_diag_send_data_3d_cfloat(int *diag_field_id, int *field_shape, float *field, char *err_msg, bool *convert_cf_data);
-extern bool cFMS_diag_send_data_4d_cfloat(int *diag_field_id, int *field_shape, float *field, char *err_msg, bool *convert_cf_data);
-extern bool cFMS_diag_send_data_5d_cfloat(int *diag_field_id, int *field_shape, float *field, char *err_msg, bool *convert_cf_data);
-extern bool cFMS_diag_send_data_2d_cdouble(int *diag_field_id, int *field_shape, double *field, char *err_msg, bool *convert_cf_data);
-extern bool cFMS_diag_send_data_3d_cdouble(int *diag_field_id, int *field_shape, double *field, char *err_msg, bool *convert_cf_data);
-extern bool cFMS_diag_send_data_4d_cdouble(int *diag_field_id, int *field_shape, double *field, char *err_msg, bool *convert_cf_data);
-extern bool cFMS_diag_send_data_5d_cdouble(int *diag_field_id, int *field_shape, double *field, char *err_msg, bool *convert_cf_data);
+extern bool cFMS_diag_send_data_2d_cint(int *diag_field_id, int *field_shape, int *field, char *err_msg, bool *convert_cf_data, int* time);
+extern bool cFMS_diag_send_data_3d_cint(int *diag_field_id, int *field_shape, int *field, char *err_msg, bool *convert_cf_data, int* time);
+extern bool cFMS_diag_send_data_4d_cint(int *diag_field_id, int *field_shape, int *field, char *err_msg, bool *convert_cf_data, int* time);
+extern bool cFMS_diag_send_data_5d_cint(int *diag_field_id, int *field_shape, int *field, char *err_msg, bool *convert_cf_data, int* time);
+extern bool cFMS_diag_send_data_2d_cfloat(int *diag_field_id, int *field_shape, float *field, char *err_msg, bool *convert_cf_data, int* time);
+extern bool cFMS_diag_send_data_3d_cfloat(int *diag_field_id, int *field_shape, float *field, char *err_msg, bool *convert_cf_data, int* time);
+extern bool cFMS_diag_send_data_4d_cfloat(int *diag_field_id, int *field_shape, float *field, char *err_msg, bool *convert_cf_data, int* time);
+extern bool cFMS_diag_send_data_5d_cfloat(int *diag_field_id, int *field_shape, float *field, char *err_msg, bool *convert_cf_data, int* time);
+extern bool cFMS_diag_send_data_2d_cdouble(int *diag_field_id, int *field_shape, double *field, char *err_msg, bool *convert_cf_data, int* time);
+extern bool cFMS_diag_send_data_3d_cdouble(int *diag_field_id, int *field_shape, double *field, char *err_msg, bool *convert_cf_data, int* time);
+extern bool cFMS_diag_send_data_4d_cdouble(int *diag_field_id, int *field_shape, double *field, char *err_msg, bool *convert_cf_data, int* time);
+extern bool cFMS_diag_send_data_5d_cdouble(int *diag_field_id, int *field_shape, double *field, char *err_msg, bool *convert_cf_data, int* time);
 
 #endif

--- a/c_diag_manager/include/c_diag_axis_init.fh
+++ b/c_diag_manager/include/c_diag_axis_init.fh
@@ -5,7 +5,7 @@
 #define CFMS_DIAG_AXIS_INIT_BINDC_ "cFMS_diag_axis_init_cfloat"
 #define CFMS_AXIS_DATA_KIND_        c_float
 #include "c_diag_axis_init.inc"
-  
+
 #undef  CFMS_DIAG_AXIS_INIT_
 #undef  CFMS_DIAG_AXIS_INIT_BINDC_
 #undef  CFMS_AXIS_DATA_KIND_

--- a/c_diag_manager/include/c_diag_axis_init.inc
+++ b/c_diag_manager/include/c_diag_axis_init.inc
@@ -1,7 +1,7 @@
 function CFMS_DIAG_AXIS_INIT_(name, naxis_data, axis_data, units, cart_name, domain_id,    &
      long_name, direction, set_name, edges, aux, req, tile_count, domain_position, not_xy) &
      bind(C, name=CFMS_DIAG_AXIS_INIT_BINDC_)
-    
+
     implicit none
     character(c_char), intent(in) :: name(NAME_LENGTH)
     integer,           intent(in) :: naxis_data
@@ -20,15 +20,15 @@ function CFMS_DIAG_AXIS_INIT_(name, naxis_data, axis_data, units, cart_name, dom
     logical(c_bool),   intent(in), optional :: not_xy
 
     type(FmsMppDomain2D), pointer :: domain
-    
+
     character(NAME_LENGTH-1) :: name_f
     character(NAME_LENGTH-1) :: units_f
     character(NAME_LENGTH-1) :: cart_name_f
     character(NAME_LENGTH-1) :: set_name_f
     character(NAME_LENGTH-1) :: long_name_f
     character(NAME_LENGTH-1) :: aux_f
-    character(NAME_LENGTH-1) :: req_f    
-    
+    character(NAME_LENGTH-1) :: req_f
+
     integer :: CFMS_DIAG_AXIS_INIT_
 
     logical :: not_xy_f
@@ -36,7 +36,7 @@ function CFMS_DIAG_AXIS_INIT_(name, naxis_data, axis_data, units, cart_name, dom
     set_name_f = ""
     aux_f = "none"
     req_f = "none"
-    
+
     name_f      = fms_string_utils_c2f_string(name)
     units_f     = fms_string_utils_c2f_string(units)
     cart_name_f = fms_string_utils_c2f_string(cart_name)
@@ -66,7 +66,7 @@ function CFMS_DIAG_AXIS_INIT_(name, naxis_data, axis_data, units, cart_name, dom
                                               tile_count = tile_count, &
                                               domain_position = domain_position)
     nullify(domain)
-    
+
   end function CFMS_DIAG_AXIS_INIT_
 
 

--- a/c_diag_manager/include/c_register_diag_field.fh
+++ b/c_diag_manager/include/c_register_diag_field.fh
@@ -14,7 +14,7 @@
 #include "c_register_diag_field.inc"
 
 
-! cfloats  
+! cfloats
 #undef  CFMS_REGISTER_DIAG_FIELD_SCALAR_
 #undef  CFMS_REGISTER_DIAG_FIELD_SCALAR_BINDC_
 #undef  CFMS_REGISTER_DIAG_FIELD_SCALAR_TYPE_
@@ -28,7 +28,7 @@
 #define CFMS_REGISTER_DIAG_FIELD_ARRAY_BINDC_ "cFMS_register_diag_field_array_cfloat"
 #define CFMS_REGISTER_DIAG_FIELD_ARRAY_TYPE_   real(c_float)
 #include "c_register_diag_field.inc"
-  
+
 
 ! cdoubles
 #undef  CFMS_REGISTER_DIAG_FIELD_SCALAR_

--- a/c_diag_manager/include/c_register_diag_field.inc
+++ b/c_diag_manager/include/c_register_diag_field.inc
@@ -1,12 +1,13 @@
-function CFMS_REGISTER_DIAG_FIELD_SCALAR_(module_name, field_name, long_name, units,                    &
+function CFMS_REGISTER_DIAG_FIELD_SCALAR_(module_name, field_name, long_name, units, time,              &
      missing_value, range, standard_name, do_not_log, err_msg, area, volume, realm, multiple_send_data) &
      bind(C, name=CFMS_REGISTER_DIAG_FIELD_SCALAR_BINDC_)
-  
+
   implicit none
   character(c_char), intent(in) :: module_name(NAME_LENGTH)
   character(c_char), intent(in) :: field_name(NAME_LENGTH)
   character(c_char), intent(in),  optional :: long_name(NAME_LENGTH)
   character(c_char), intent(in),  optional :: units(NAME_LENGTH)
+  integer(c_int), intent(in), optional :: time(7) !< year, month, date, hours, minutes, seconds, ticks
   character(c_char), intent(in),  optional :: standard_name(NAME_LENGTH)
   CFMS_REGISTER_DIAG_FIELD_SCALAR_TYPE_, intent(in), optional :: missing_value
   CFMS_REGISTER_DIAG_FIELD_SCALAR_TYPE_, intent(in), optional :: range(2)
@@ -16,7 +17,7 @@ function CFMS_REGISTER_DIAG_FIELD_SCALAR_(module_name, field_name, long_name, un
   integer,           intent(in),  optional :: volume
   character(c_char), intent(in),  optional :: realm(NAME_LENGTH)
   logical(c_bool),   intent(in),  optional :: multiple_send_data
-  
+
   character(len=NAME_LENGTH-1) :: module_name_f    = ''
   character(len=NAME_LENGTH-1) :: field_name_f     = ''
   character(len=NAME_LENGTH-1) :: long_name_f      = ''
@@ -28,7 +29,9 @@ function CFMS_REGISTER_DIAG_FIELD_SCALAR_(module_name, field_name, long_name, un
   logical :: do_not_log_f
   logical :: multiple_send_data_f
   integer :: CFMS_REGISTER_DIAG_FIELD_SCALAR_
-  
+
+  type(FmsTime_type) :: field_init_time
+
   module_name_f = ''
   field_name_f = ''
   long_name_f = ''
@@ -41,14 +44,23 @@ function CFMS_REGISTER_DIAG_FIELD_SCALAR_(module_name, field_name, long_name, un
   multiple_send_data_f = .False.
 
   if(present(do_not_log)) do_not_log_f = logical(do_not_log)
-  if(present(multiple_send_data)) multiple_send_data_f = logical(multiple_send_data)  
-  
+  if(present(multiple_send_data)) multiple_send_data_f = logical(multiple_send_data)
+
   module_name_f = fms_string_utils_c2f_string(module_name)
-  field_name_f  = fms_string_utils_c2f_string(field_name)  
+  field_name_f  = fms_string_utils_c2f_string(field_name)
   if(present(units))     units_f = fms_string_utils_c2f_string(units)
   if(present(realm))     realm_f = fms_string_utils_c2f_string(realm)
   if(present(long_name)) long_name_f = fms_string_utils_c2f_string(long_name)
   if(present(standard_name)) standard_name_f = fms_string_utils_c2f_string(standard_name)
+  if(present(time)) then
+    field_init_time = fms_time_manager_set_date(year=time(1),   &
+                                           month=time(2),  &
+                                           day=time(3),    &
+                                           hour=time(4),   &
+                                           minute=time(5), &
+                                           second=time(6), &
+                                           tick=time(7))
+  endif
 
   CFMS_REGISTER_DIAG_FIELD_SCALAR_ = fms_diag_register_diag_field(module_name_f,                   &
                                                                   field_name_f,                    &
@@ -65,14 +77,12 @@ function CFMS_REGISTER_DIAG_FIELD_SCALAR_(module_name, field_name, long_name, un
                                                                   realm = realm_f,                 &
                                                                   multiple_send_data = multiple_send_data_f)
 
-  field_curr_time(CFMS_REGISTER_DIAG_FIELD_SCALAR_) = field_init_time
-  
   if(present(err_msg) .and. err_msg_f /= '') call fms_string_utils_f2c_string(err_msg, err_msg_f)
-    
+
 end function CFMS_REGISTER_DIAG_FIELD_SCALAR_
 
 
-function CFMS_REGISTER_DIAG_FIELD_ARRAY_(module_name, field_name, axes, long_name, units,            &
+function CFMS_REGISTER_DIAG_FIELD_ARRAY_(module_name, field_name, axes, long_name, units, time,      &
      missing_value, range, mask_variant, standard_name, verbose, do_not_log, err_msg, interp_method, &
      tile_count, area, volume, realm, multiple_send_data) bind(C, name=CFMS_REGISTER_DIAG_FIELD_ARRAY_BINDC_)
 
@@ -81,7 +91,8 @@ function CFMS_REGISTER_DIAG_FIELD_ARRAY_(module_name, field_name, axes, long_nam
   character(c_char), intent(in) :: field_name(NAME_LENGTH)
   integer,           intent(in), optional  :: axes(5)
   character(c_char), intent(in), optional  :: long_name(NAME_LENGTH)
-  character(c_char), intent(in), optional  :: units(NAME_LENGTH) 
+  character(c_char), intent(in), optional  :: units(NAME_LENGTH)
+  integer(c_int), intent(in), optional :: time(7) !< year, month, date, hours, minutes, seconds, ticks
   CFMS_REGISTER_DIAG_FIELD_ARRAY_TYPE_, intent(in), optional :: missing_value
   CFMS_REGISTER_DIAG_FIELD_ARRAY_TYPE_, intent(in), optional :: range(2)
   logical(c_bool),   intent(in), optional  :: mask_variant
@@ -95,7 +106,7 @@ function CFMS_REGISTER_DIAG_FIELD_ARRAY_(module_name, field_name, axes, long_nam
   integer,           intent(in), optional  :: volume
   character(c_char), intent(in), optional  :: realm(NAME_LENGTH)
   logical(c_bool),   intent(in), optional  :: multiple_send_data
-  
+
   character(len=NAME_LENGTH-1) :: module_name_f
   character(len=NAME_LENGTH-1) :: field_name_f
   character(len=NAME_LENGTH-1) :: long_name_f
@@ -108,10 +119,11 @@ function CFMS_REGISTER_DIAG_FIELD_ARRAY_(module_name, field_name, axes, long_nam
   logical :: mask_variant_f
   logical :: verbose_f
   logical :: do_not_log_f
-  logical :: multiple_send_data_f  
+  logical :: multiple_send_data_f
   integer :: naxes
-  
+
   integer :: CFMS_REGISTER_DIAG_FIELD_ARRAY_
+  type(FmsTime_type) :: field_init_time
 
   long_name_f = ''
   units_f = ''
@@ -122,7 +134,7 @@ function CFMS_REGISTER_DIAG_FIELD_ARRAY_(module_name, field_name, axes, long_nam
   mask_variant_f = .false.
   verbose_f = .false.
   do_not_log_f = .false.
-  multiple_send_data_f = .false.  
+  multiple_send_data_f = .false.
 
   module_name_f = fms_string_utils_c2f_string(module_name)
   field_name_f  = fms_string_utils_c2f_string(field_name)
@@ -136,7 +148,16 @@ function CFMS_REGISTER_DIAG_FIELD_ARRAY_(module_name, field_name, axes, long_nam
   if(present(verbose)) verbose_f = logical(verbose)
   if(present(do_not_log)) do_not_log_f = logical(do_not_log)
   if(present(multiple_send_data)) multiple_send_data_f = logical(multiple_send_data)
-  
+  if(present(time)) then
+    field_init_time = fms_time_manager_set_date(year=time(1),   &
+                                           month=time(2),  &
+                                           day=time(3),    &
+                                           hour=time(4),   &
+                                           minute=time(5), &
+                                           second=time(6), &
+                                           tick=time(7))
+  endif
+
   if(present(axes)) then
      naxes = 5 - count(axes<=0)
      CFMS_REGISTER_DIAG_FIELD_ARRAY_ = fms_diag_register_diag_field(module_name = module_name_f,     &
@@ -179,7 +200,5 @@ function CFMS_REGISTER_DIAG_FIELD_ARRAY_(module_name, field_name, axes, long_nam
                                                                     realm = realm_f,                      &
                                                                     multiple_send_data = logical(multiple_send_data))
   end if
-
-  field_curr_time(CFMS_REGISTER_DIAG_FIELD_ARRAY_) = field_init_time
 
 end function CFMS_REGISTER_DIAG_FIELD_ARRAY_

--- a/c_diag_manager/include/c_send_data.inc
+++ b/c_diag_manager/include/c_send_data.inc
@@ -1,25 +1,35 @@
 function CFMS_DIAG_SEND_DATA_(diag_field_id, field_shape, field_ptr, err_msg, &
-     convert_cf_order) bind(C, name=CFMS_DIAG_SEND_DATA_BINDC_)
-  
+     convert_cf_order, time) bind(C, name=CFMS_DIAG_SEND_DATA_BINDC_)
+
   implicit none
-  
+
   integer, intent(in) :: diag_field_id
   integer, intent(in) :: field_shape(CFMS_DIAG_SEND_DATA_FIELD_NDIM_)
   type(c_ptr), value, intent(in) :: field_ptr
   character(c_bool), intent(out), optional :: err_msg(MESSAGE_LENGTH)
   logical(c_bool), intent(in), optional :: convert_cf_order
-  
+  integer, intent(in), optional :: time(7)
+  type(FmsTime_type) :: curr_time
+
   character(MESSAGE_LENGTH-1) :: err_msg_f
-  logical(c_bool) :: CFMS_DIAG_SEND_DATA_  
+  logical(c_bool) :: CFMS_DIAG_SEND_DATA_
 
   CFMS_DIAG_SEND_DATA_FIELD_TYPE_, allocatable :: field(CFMS_DIAG_SEND_DATA_FIELD_ASSUMED_SHAPE_)
-  
+
   allocate(field(CFMS_DIAG_SEND_DATA_FIELD_SHAPE_))
   call cFMS_pointer_to_array(field_ptr, field_shape, field, convert_cf_order)
-  
+
+  curr_time = fms_time_manager_set_date(year=time(1),   &
+                                        month=time(2),  &
+                                        day=time(3),    &
+                                        hour=time(4),   &
+                                        minute=time(5), &
+                                        second=time(6), &
+                                        tick=time(7))
+
   CFMS_DIAG_SEND_DATA_ = fms_diag_send_data(diag_field_id = diag_field_id, &
                                        field = field,                      &
-                                       time = field_curr_time(diag_field_id), &
+                                       time = curr_time, &
                                        err_msg = err_msg_f)
 
   CFMS_DIAG_SEND_DATA_ = logical(CFMS_DIAG_SEND_DATA_, kind=c_bool)

--- a/c_fms/c_fms.h
+++ b/c_fms/c_fms.h
@@ -234,4 +234,6 @@ extern void cFMS_v_update_domains_float_5d(int* fieldx_shape, float* fieldx, int
 extern int cFMS_define_cubic_mosaic(int* ni, int* nj, int* global_indices, int* layout, int* ntiles,
   int* halo, bool* use_memsize);
 
+enum FmsTimes { YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, TICK};
+
 #endif

--- a/test_cfms/c_diag_manager/test_send_data.c
+++ b/test_cfms/c_diag_manager/test_send_data.c
@@ -11,12 +11,13 @@
 
 //TODO:  add reading in the outputted file for correctness
 //Currently, answers have been checked separately/manually for correctness
-int main() 
+int main()
 {
-  
+
+  printf("test started\n");
   int domain_id = -99;
   int id_x, id_y, id_z;
-  
+
   int id_var3;
   int var3_shape[3] = {NX, NY, NZ};
   float *var3;
@@ -26,9 +27,9 @@ int main()
   float *var2;
 
   int calendar_type = NOLEAP;
-    
+
   var3 = (float *)malloc(NX*NY*NZ*sizeof(float));
-  int ijk = 0;  
+  int ijk = 0;
   for(int i=0; i<NX; i++) {
     for(int j=0; j<NY; j++) {
       for(int k=0; k<NZ; k++) {
@@ -38,49 +39,55 @@ int main()
   }
 
   var2 = (float *)malloc(NX*NY*sizeof(float));
-  int ij = 0;  
+  int ij = 0;
   for(int i=0; i<NX; i++) {
     for(int j=0; j<NY; j++) {
       var2[ij++] = i*10. + j*1.;
     }
-  }    
-  
+  }
+  printf("data allocated and set\n");
+
   cFMS_init(NULL, NULL, NULL, NULL, &calendar_type);
+  printf("cfms initialized\n");
+  int* npes = (int*) malloc(sizeof(int));
+  *npes = cFMS_npes();
 
   // define domain
+  // TODO helper routines seem to be crashing; instead we'll create the domain directly
   {
-    cDomainStruct cdomain;
+    //cDomainStruct cdomain;
     int global_indices[4] = {0, NX-1, 0, NY-1};
-    int layout[2] = {1,1};
+    int layout[2] = {1,*npes};
     int io_layout[2] = {1,1};
-    cFMS_null_cdomain(&cdomain);  
-    cdomain.global_indices = global_indices;
-    cdomain.layout = layout;
-    domain_id = cFMS_define_domains_easy(cdomain);
+    //cFMS_null_cdomain(&cdomain);
+    //cdomain.global_indices = global_indices;
+    //cdomain.layout = layout;
+    //cdomain.npes = (int*) malloc(sizeof(int));
+    //domain_id = cFMS_define_domains_easy(cdomain);
+    domain_id = cFMS_define_domains(global_indices, layout, npes,
+      NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+      NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     cFMS_define_io_domain(io_layout,&domain_id);
+   //function cFMS_define_domains(global_indices, layout, npes, pelist,            &
+   //   xflags, yflags, xhalo, yhalo, xextent, yextent, maskmap, name,           &
+   //   symmetry, memory_size, whalo, ehalo, shalo, nhalo, is_mosaic, tile_count,&
+   //   tile_id, complete, x_cyclic_offset, y_cyclic_offset) bind(C, name="cFMS_define_domains")
   }
-  
+  cFMS_set_current_domain(&domain_id);
+
+  printf("domain defined\n");
+
   // diag manager init
+  int time_init[7] = {2, 1, 1, 1, 1, 1, 0}; // 1/1/2 01:01:01
   {
     int  diag_model_subset = DIAG_ALL;
-    int *time_init = NULL;
     char err_msg[NAME_LENGTH] = "None";
     cFMS_diag_init(&diag_model_subset, time_init, err_msg);
-
-    //test module_is_initialized
-    cFMS_diag_init(&diag_model_subset, time_init, err_msg);
   }
+  printf("diag manager initialized");
 
-  bool module_is_initialized = c_diag_manager_is_initialized();
-  if(!module_is_initialized){
-    cFMS_error(FATAL, "module is not initialized");
-    exit(EXIT_FAILURE);
-  }
-  
-  cFMS_set_current_domain(&domain_id);
-  
   //diag axis init x
-  {    
+  {
     char name[NAME_LENGTH] = "x";
     int naxis_data = NX;
     double x[NX];
@@ -96,13 +103,13 @@ int main()
     int *domain_position = NULL;
 
     for(int i=0; i<NX; i++) x[i] = i;
-    
-    id_x = cFMS_diag_axis_init_cdouble(name, &naxis_data, x, units, cart_name, &domain_id, long_name, direction, 
+
+    id_x = cFMS_diag_axis_init_cdouble(name, &naxis_data, x, units, cart_name, &domain_id, long_name, direction,
                                        set_name, edges, aux, req, tile_count, domain_position, NULL);
   }
 
   //diag axis init y
-  {    
+  {
     char name[NAME_LENGTH] = "y";
     int naxis_data = NY;
     double y[NY];
@@ -118,13 +125,13 @@ int main()
     int *domain_position = NULL;
 
     for(int j=0; j<NY; j++) y[j] = j;
-    
-    id_y = cFMS_diag_axis_init_cdouble(name, &naxis_data, y, units, cart_name, &domain_id, long_name, direction, 
+
+    id_y = cFMS_diag_axis_init_cdouble(name, &naxis_data, y, units, cart_name, &domain_id, long_name, direction,
                                        set_name, edges, aux, req, tile_count, domain_position, NULL);
   }
 
   //diag axis init z
-  {    
+  {
     char name[NAME_LENGTH] = "z";
     int naxis_data = NZ;
     double z[NZ];
@@ -141,11 +148,11 @@ int main()
     bool not_xy = true;
 
     for(int k=0; k<NZ; k++) z[k] = k;
-    
-    id_z = cFMS_diag_axis_init_cdouble(name, &naxis_data, z, units, cart_name, NULL, long_name, direction, 
+
+    id_z = cFMS_diag_axis_init_cdouble(name, &naxis_data, z, units, cart_name, NULL, long_name, direction,
                                        set_name, edges, aux, req, tile_count, domain_position, &not_xy);
   }
-  
+
   // register_diag_field var3
   {
     char module_name[NAME_LENGTH] = "atm_mod";
@@ -167,23 +174,10 @@ int main()
     bool *multiple_send_data = NULL;
 
     char err_msg[MESSAGE_LENGTH]="None";
-    
-    int year = 2;
-    int month = 1;
-    int day = 1;
-    int hour = 1;
-    int minute = 1;
-    int second = 1;
-    int *tick = NULL;
-    
-    cFMS_diag_set_field_init_time(&year, &month, &day, &hour, &minute, &second, tick, err_msg);
-    id_var3 = cFMS_register_diag_field_array_cfloat(module_name, field_name, axes, long_name, units, &missing_value, range,
+
+    id_var3 = cFMS_register_diag_field_array_cfloat(module_name, field_name, axes, long_name, units, time_init, &missing_value, range,
                                                     mask_variant, standard_name, verbose, do_not_log, err_msg, interp_method,
                                                     tile_count, area, volume, realm, multiple_send_data);
-    int ddays = 0;
-    int dseconds = 60*60;
-    int dticks = 0;
-    cFMS_diag_set_field_timestep(&id_var3, &dseconds, &ddays, &dticks,  NULL);
   }
 
   // register_diag_field var2
@@ -207,40 +201,26 @@ int main()
     bool *multiple_send_data = NULL;
 
     char err_msg[MESSAGE_LENGTH]="None";
-    
-    int year = 2;
-    int month = 1;
-    int day = 1;
-    int hour = 1;
-    int minute = 1;
-    int second = 1;
-    int *tick = NULL;
-    
-    cFMS_diag_set_field_init_time(&year, &month, &day, &hour, &minute, &second, tick, err_msg);
-    id_var2 = cFMS_register_diag_field_array_cfloat(module_name, field_name, axes, long_name, units, &missing_value, range,
+
+    id_var2 = cFMS_register_diag_field_array_cfloat(module_name, field_name, axes, long_name, units, time_init, &missing_value, range,
                                                     mask_variant, standard_name, verbose, do_not_log, err_msg, interp_method,
                                                     tile_count, area, volume, realm, multiple_send_data);
-    int ddays = 0;
-    int dseconds = 60*60;
-    int dticks = 0;
-    cFMS_diag_set_field_timestep(&id_var2, &dseconds, &ddays, &dticks,  NULL);
   }
 
-  
-  // cFMS_diag_set_time_end
-  {
-    int year = 2;
-    int month = 1;
-    int day = 2;
-    int hour = 1;
-    int minute = 1;
-    int second = 1;
-    int *tick = NULL;
-    cFMS_diag_set_time_end(&year, &month, &day, &hour, &minute, &second, tick, NULL);    
-  }
+  // set end time
+  int time_end[7] = {2,1,2,1,1,1,0 }; // 1/2/2 01:01:01
+  cFMS_diag_set_time_end(time_end, NULL);
 
   // send_data
-  for(int itime=0; itime<24; itime++) {    
+  int* curr_time = time_init;
+  for(int itime=0; itime<24; itime++) {
+
+    curr_time[HOUR]++;
+    if(curr_time[HOUR] == 24){
+      curr_time[HOUR] = 0;
+      curr_time[DAY]++;
+    }
+
     int ijk = 0;
     for(int i=0; i<NX; i++){
       for(int j=0; j<NY; j++){
@@ -250,9 +230,7 @@ int main()
         }
       }
     }
-    cFMS_diag_advance_field_time(&id_var3);
-    cFMS_diag_send_data_3d_cfloat(&id_var3, var3_shape, var3, NULL, NULL);
-    cFMS_diag_send_complete(&id_var3, NULL);
+    cFMS_diag_send_data_3d_cfloat(&id_var3, var3_shape, var3, NULL, NULL, curr_time);
 
     int ij = 0;
     for(int i=0; i<NX; i++){
@@ -261,15 +239,15 @@ int main()
         ij++;
       }
     }
-    cFMS_diag_advance_field_time(&id_var2);
-    cFMS_diag_send_data_2d_cfloat(&id_var2, var2_shape, var2, NULL, NULL);
-    cFMS_diag_send_complete(&id_var2, NULL);    
+    cFMS_diag_send_data_2d_cfloat(&id_var2, var2_shape, var2, NULL, NULL, curr_time);
+
+    cFMS_diag_send_complete(curr_time, NULL);
   }
 
-  cFMS_diag_end();
-  
+  cFMS_diag_end(time_end);
+
   cFMS_end();
   return EXIT_SUCCESS;
-  
+
 }
-  
+

--- a/test_cfms/c_diag_manager/test_send_data.sh
+++ b/test_cfms/c_diag_manager/test_send_data.sh
@@ -34,7 +34,6 @@ EOF
 cat <<EOF > diag_table.yaml
 title: test_diag_manager
 base_date: 2 1 1 1 1 1
-
 diag_files:
 - file_name: test_send_data
   freq: 1 hours
@@ -53,6 +52,8 @@ diag_files:
     output_name: var2_avg
 EOF
 
-test_expect_success "c_diag_manager send_data" 'mpirun -n 1  ./test_send_data'
+test_expect_success "c_diag_manager basic diagnostics functionality with 1 pe" 'mpirun -n 1  ./test_send_data'
+
+test_expect_success "c_diag_manager basic diagnostics functionality with 4 pes" 'mpirun -n 4  ./test_send_data'
 test_done
 


### PR DESCRIPTION
Managing the time types via an array seems to cause issues when registering more than one field with MPI, so this removes the module-level time arrays and also modifies the routines to take the time as an argument.

This should make it mirror the diag manager calls in fortran a bit more, which i think is useful.