### PR TITLE
CMake installation method

### DIFF
--- a/.github/workflows/github_cmake_gnu.yaml
+++ b/.github/workflows/github_cmake_gnu.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install netcdf-bin libnetcdf-dev libnetcdff-dev libyaml-dev
+        sudo apt-get install netcdf-bin libnetcdf-dev libnetcdff-dev libyaml-dev -qq mpich libmpich-dev
     - name: test
       run: |
         export FC="mpifort"

--- a/.github/workflows/github_cmake_gnu.yaml
+++ b/.github/workflows/github_cmake_gnu.yaml
@@ -1,0 +1,24 @@
+name: Build libcFMS test with CMake
+
+on: [push, pull_request]
+
+# cancel running jobs if theres a newer push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
+jobs:
+  build_external:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/noaa-gfdl/fms/fms-ci-rocky-gnu:13.2.0
+      env:
+        TEST_VERBOSE: 1
+    steps:
+    - name: checkout code
+      uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+    - name: test
+      run: cmake -B build -DCFMS_TESTS=ON

--- a/.github/workflows/github_cmake_gnu.yaml
+++ b/.github/workflows/github_cmake_gnu.yaml
@@ -30,7 +30,7 @@ jobs:
       run: |
         export FC="mpifort"
         export CC="mpicc"
-        export CFLAGS = "-g -O0"
+        export CFLAGS="-g -O0"
         export FCFLAGS="-g -O0 -W -fbacktrace -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow"
         cmake -B build -DCFMS_TESTS=ON
         cmake --build build

--- a/.github/workflows/github_cmake_gnu.yaml
+++ b/.github/workflows/github_cmake_gnu.yaml
@@ -23,9 +23,7 @@ jobs:
     - name: install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libnetcdf-dev libnetcdff-dev libhdf5-dev
-        sudo apt-get install -y -qq mpich libmpich-dev
-        sudo apt-get install -y libyaml-dev
+        sudo apt-get install netcdf-bin libnetcdf-dev libnetcdff-dev libyaml-dev
     - name: test
       run: |
         export FC="mpifort"

--- a/.github/workflows/github_cmake_gnu.yaml
+++ b/.github/workflows/github_cmake_gnu.yaml
@@ -11,24 +11,20 @@ concurrency:
 jobs:
   cmake_install:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/noaa-gfdl/fms/fms-ci-rocky-gnu:13.2.0
+      env:
+        PKG_CONFIG_PATH: "/opt/views/view/lib64/pkgconfig:/opt/views/view/lib/pkgconfig:/opt/views/view/share/pkgconfig"
     steps:
     - name: checkout code
       uses: actions/checkout@v4
       with:
         submodules: 'recursive'
-    - name: Setup CMake
-      uses: jwlawson/actions-setup-cmake@v2
-      with:
-        cmake-version: '3.25.x'
-    - name: install dependencies
+    - name: Generate makefiles with CMake
       run: |
-        sudo apt-get update
-        sudo apt-get install netcdf-bin libnetcdf-dev libnetcdff-dev libyaml-dev -qq mpich libmpich-dev
-    - name: test
-      run: |
-        export FC="mpifort"
-        export CC="mpicc"
-        export CFLAGS="-g -O0"
-        export FCFLAGS="-g -O0 -W -fbacktrace -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow"
-        cmake -B build -DCFMS_TESTS=ON
-        cmake --build build
+        cmake -B build -DCFMS_TESTS=on -DNetCDF_ROOT=/opt/view -DLIBYAML_ROOT=/opt/view
+    - name: Build library and tests
+      run: make -C build
+    - name: Run tests
+      run: cd build && ctest --output-on-failure
+        

--- a/.github/workflows/github_cmake_gnu.yaml
+++ b/.github/workflows/github_cmake_gnu.yaml
@@ -21,4 +21,9 @@ jobs:
       with:
         submodules: 'recursive'
     - name: test
-      run: cmake -B build -DCFMS_TESTS=ON
+      run: |
+        export FC="mpifort"
+        export CC="mpicc"
+        export CFLAGS="`nc-config --cflags`"
+        export FCFLAGS="`nf-config --fflags`"
+        cmake -B build -DCFMS_TESTS=ON

--- a/.github/workflows/github_cmake_gnu.yaml
+++ b/.github/workflows/github_cmake_gnu.yaml
@@ -22,6 +22,7 @@ jobs:
         submodules: 'recursive'
     - name: test
       run: |
+        echo "`nc-config --cflags`"
         export FC="mpifort"
         export CC="mpicc"
         export CFLAGS="`nc-config --cflags`"

--- a/.github/workflows/github_cmake_gnu.yaml
+++ b/.github/workflows/github_cmake_gnu.yaml
@@ -9,17 +9,23 @@ concurrency:
 
 
 jobs:
-  build_external:
+  cmake_install:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/noaa-gfdl/fms/fms-ci-rocky-gnu:13.2.0
-      env:
-        TEST_VERBOSE: 1
     steps:
     - name: checkout code
       uses: actions/checkout@v4
       with:
         submodules: 'recursive'
+    - name: Setup CMake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '3.25.x'
+    - name: install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libnetcdf-dev libhdf5-dev
+        sudo apt-get install -y -qq mpich libmpich-dev
+        sudo apt-get install -y libyaml-dev
     - name: test
       run: |
         echo "`nc-config --cflags`"

--- a/.github/workflows/github_cmake_gnu.yaml
+++ b/.github/workflows/github_cmake_gnu.yaml
@@ -28,9 +28,6 @@ jobs:
         sudo apt-get install -y libyaml-dev
     - name: test
       run: |
-        echo "`nc-config --cflags`"
         export FC="mpifort"
         export CC="mpicc"
-        export CFLAGS="`nc-config --cflags`"
-        export FCFLAGS="`nf-config --fflags`"
         cmake -B build -DCFMS_TESTS=ON

--- a/.github/workflows/github_cmake_gnu.yaml
+++ b/.github/workflows/github_cmake_gnu.yaml
@@ -31,3 +31,4 @@ jobs:
         export FC="mpifort"
         export CC="mpicc"
         cmake -B build -DCFMS_TESTS=ON
+        cmake --build build

--- a/.github/workflows/github_cmake_gnu.yaml
+++ b/.github/workflows/github_cmake_gnu.yaml
@@ -30,5 +30,7 @@ jobs:
       run: |
         export FC="mpifort"
         export CC="mpicc"
+        export CFLAGS = "-g -O0"
+        export FCFLAGS="-g -O0 -W -fbacktrace -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow"
         cmake -B build -DCFMS_TESTS=ON
         cmake --build build

--- a/.github/workflows/github_cmake_gnu.yaml
+++ b/.github/workflows/github_cmake_gnu.yaml
@@ -14,7 +14,6 @@ jobs:
     container:
       image: ghcr.io/noaa-gfdl/fms/fms-ci-rocky-gnu:13.2.0
       env:
-        EXCLUDE_TESTS: "test_mpp_nesting|test_bc_restart|test_collective_io|test_fms2_io|test_io_with_mask|test_diag_manager2"
         PKG_CONFIG_PATH: "/opt/views/view/lib64/pkgconfig:/opt/views/view/lib/pkgconfig:/opt/views/view/share/pkgconfig"
     steps:
     - name: checkout code
@@ -27,5 +26,5 @@ jobs:
     - name: Build library and tests
       run: make -C build
     - name: Run tests
-      run: cd build && ctest -E "${EXCLUDE_TESTS}" --output-on-failure
+      run: cd build && ctest --output-on-failure
         

--- a/.github/workflows/github_cmake_gnu.yaml
+++ b/.github/workflows/github_cmake_gnu.yaml
@@ -14,7 +14,7 @@ jobs:
     container:
       image: ghcr.io/noaa-gfdl/fms/fms-ci-rocky-gnu:13.2.0
       env:
-        EXCLUDE_TESTS: "test_mpp_nesting|test_bc_restart|test_collective_io|test_fms2_io|test_io_with_mask"
+        EXCLUDE_TESTS: "test_mpp_nesting|test_bc_restart|test_collective_io|test_fms2_io|test_io_with_mask|test_diag_manager2"
         PKG_CONFIG_PATH: "/opt/views/view/lib64/pkgconfig:/opt/views/view/lib/pkgconfig:/opt/views/view/share/pkgconfig"
     steps:
     - name: checkout code

--- a/.github/workflows/github_cmake_gnu.yaml
+++ b/.github/workflows/github_cmake_gnu.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libnetcdf-dev lib netcdff-dev libhdf5-dev
+        sudo apt-get install -y libnetcdf-dev libnetcdff-dev libhdf5-dev
         sudo apt-get install -y -qq mpich libmpich-dev
         sudo apt-get install -y libyaml-dev
     - name: test

--- a/.github/workflows/github_cmake_gnu.yaml
+++ b/.github/workflows/github_cmake_gnu.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libnetcdf-dev libhdf5-dev
+        sudo apt-get install -y libnetcdf-dev lib netcdff-dev libhdf5-dev
         sudo apt-get install -y -qq mpich libmpich-dev
         sudo apt-get install -y libyaml-dev
     - name: test

--- a/.github/workflows/github_cmake_gnu.yaml
+++ b/.github/workflows/github_cmake_gnu.yaml
@@ -14,6 +14,7 @@ jobs:
     container:
       image: ghcr.io/noaa-gfdl/fms/fms-ci-rocky-gnu:13.2.0
       env:
+        EXCLUDE_TESTS: "test_mpp_nesting|test_bc_restart|test_collective_io|test_fms2_io|test_io_with_mask"
         PKG_CONFIG_PATH: "/opt/views/view/lib64/pkgconfig:/opt/views/view/lib/pkgconfig:/opt/views/view/share/pkgconfig"
     steps:
     - name: checkout code
@@ -26,5 +27,5 @@ jobs:
     - name: Build library and tests
       run: make -C build
     - name: Run tests
-      run: cd build && ctest --output-on-failure
+      run: cd build && ctest -E "${EXCLUDE_TESTS}" --output-on-failure
         

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,13 +47,13 @@ endif()
 
 # Find dependencies
 
-FetchContent_Declare(
-    FMS
-    GIT_REPOSITORY https://github.com/fmalatino/FMS.git
-    GIT_TAG optional_tests_cmake
-)
-FetchContent_MakeAvailable(FMS)
-# add_subdirectory(FMS)
+# FetchContent_Declare(
+#     FMS
+#     GIT_REPOSITORY https://github.com/NOAA-GFDL/FMS.git
+#     GIT_TAG 043ab2f6037af92997aa72a467430e95c03652ae
+# )
+# FetchContent_MakeAvailable(FMS)
+add_subdirectory(FMS)
 
 list(APPEND cfms_src_files
   c_constants/c_constants.F90
@@ -90,7 +90,7 @@ target_include_directories(cFMS PRIVATE
   c_fms_utils/include
   c_horiz_interp/include
 #   FMS/include
-  ${CMAKE_SOURCE_DIR}/FMS/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/FMS/include
 )
 
 install(TARGETS cFMS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,6 @@ endif()
 # FetchContent_MakeAvailable(FMS)
 add_subdirectory(FMS)
 
-# list(APPEND CMAKE_MODULE_PATH ${FMS_SOURCE_DIR}/cmake)
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/FMS/cmake)
-
 list(APPEND cfms_src_files
   c_constants/c_constants.F90
   c_data_override/c_data_override.F90
@@ -82,6 +79,7 @@ add_library(cFMS SHARED
 
 target_link_libraries(cFMS PUBLIC
   FMS::fms
+  ${LIBYAML_LIBRARIES}
 )
 
 target_include_directories(cFMS PRIVATE
@@ -99,9 +97,5 @@ install(TARGETS cFMS
 )
 install(FILES ${cfms_header_files}
     DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
-
-
-
-
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,13 +47,13 @@ endif()
 
 # Find dependencies
 
-# FetchContent_Declare(
-#     FMS
-#     GIT_REPOSITORY https://github.com/fmalatino/FMS.git
-#     GIT_TAG optional_tests_cmake
-# )
-# FetchContent_MakeAvailable(FMS)
-add_subdirectory(FMS)
+FetchContent_Declare(
+    FMS
+    GIT_REPOSITORY https://github.com/fmalatino/FMS.git
+    GIT_TAG optional_tests_cmake
+)
+FetchContent_MakeAvailable(FMS)
+# add_subdirectory(FMS)
 
 list(APPEND cfms_src_files
   c_constants/c_constants.F90
@@ -89,8 +89,8 @@ target_include_directories(cFMS PRIVATE
   c_fms/include
   c_fms_utils/include
   c_horiz_interp/include
-  FMS/include
-#   ${CMAKE_SOURCE_DIR}/FMS/include
+#   FMS/include
+  ${CMAKE_SOURCE_DIR}/FMS/include
 )
 
 install(TARGETS cFMS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,4 +98,8 @@ install(TARGETS cFMS
 install(FILES ${cfms_header_files}
     DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
 
+# Tests
+
+
+
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,20 +45,17 @@ if(NOT CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|GNU|IntelLLVM)$")
 endif()
 
 # Find dependencies
-FetchContent_Declare(
-    FMS
-    GIT_REPOSITORY https://github.com/NOAA-GFDL/FMS.git
-    GIT_TAG fbbe8f6abaae0b307951c023b408b37a45f806cb
-)
-FetchContent_MakeAvailable(FMS)
-# add_subdirectory(FMS)
 
-list(APPEND CMAKE_MODULE_PATH ${FMS_SOURCE_DIR}/cmake)
+# FetchContent_Declare(
+#     FMS
+#     GIT_REPOSITORY https://github.com/NOAA-GFDL/FMS.git
+#     GIT_TAG fbbe8f6abaae0b307951c023b408b37a45f806cb
+# )
+# FetchContent_MakeAvailable(FMS)
+add_subdirectory(FMS)
 
-# Append directory that contains CMake Modules for building FMS and cFMS
-# list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/FMS/cmake)
-
-# set(TARGET_NAME libcFMS)
+# list(APPEND CMAKE_MODULE_PATH ${FMS_SOURCE_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/FMS/cmake)
 
 list(APPEND cfms_src_files
   c_constants/c_constants.F90
@@ -93,8 +90,8 @@ target_include_directories(cFMS PRIVATE
   c_fms/include
   c_fms_utils/include
   c_horiz_interp/include
-#   FMS/include
-  ${CMAKE_SOURCE_DIR}/FMS/include
+  FMS/include
+  # ${CMAKE_SOURCE_DIR}/FMS/include
 )
 
 install(TARGETS cFMS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,13 +47,12 @@ endif()
 
 # Find dependencies
 
-# FetchContent_Declare(
-#     FMS
-#     GIT_REPOSITORY https://github.com/NOAA-GFDL/FMS.git
-#     GIT_TAG 043ab2f6037af92997aa72a467430e95c03652ae
-# )
-# FetchContent_MakeAvailable(FMS)
-add_subdirectory(FMS)
+FetchContent_Declare(
+    FMS
+    GIT_REPOSITORY https://github.com/NOAA-GFDL/FMS.git
+    GIT_TAG 043ab2f6037af92997aa72a467430e95c03652ae
+)
+FetchContent_MakeAvailable(FMS)
 
 list(APPEND cfms_src_files
   c_constants/c_constants.F90
@@ -89,7 +88,6 @@ target_include_directories(cFMS PRIVATE
   c_fms/include
   c_fms_utils/include
   c_horiz_interp/include
-#   FMS/include
   ${CMAKE_CURRENT_SOURCE_DIR}/FMS/include
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,110 @@
+#***********************************************************************
+#*                             Apache License 2.0
+#*
+#* This file is part of the GFDL Flexible Modeling System (FMS).
+#*
+#* Licensed under the Apache License, Version 2.0 (the "License");
+#* you may not use this file except in compliance with the License.
+#* You may obtain a copy of the License at
+#*
+#*     http://www.apache.org/licenses/LICENSE-2.0
+#*
+#* FMS is distributed in the hope that it will be useful, but WITHOUT
+#* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied;
+#* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+#* PARTICULAR PURPOSE. See the License for the specific language
+#* governing permissions and limitations under the License.
+#***********************************************************************
+
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+
+# Build options
+option(PORTABLE_KINDS "Enable compiler defition -DPORTABLE_KINDS" ON)
+option(WITH_YAML "Enable compiler definition -Duse_yaml" ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+include(FetchContent)
+
+#Define the cmake project
+project(cFMS
+    VERSION 2026.01.0
+    DESCRIPTION "C Access to GFDL FMS Library"
+    HOMEPAGE_URL "https://github.com/NOAA-GFDL/cFMS"
+    LANGUAGES C Fortran)
+
+if(NOT CMAKE_C_COMPILER_ID MATCHES "^(Intel|GNU|Clang|IntelLLVM)$")
+    message(
+        WARNING "Compiler not officially supported: ${CMAKE_C_COMPILER_ID)}"
+    )
+endif()
+
+if(NOT CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|GNU|IntelLLVM)$")
+    message(
+        WARNING "Compiler not officially supported: ${CMAKE_Fortran_COMPILER_ID}"
+    )
+endif()
+
+# Find dependencies
+FetchContent_Declare(
+    FMS
+    GIT_REPOSITORY https://github.com/NOAA-GFDL/FMS.git
+    GIT_TAG fbbe8f6abaae0b307951c023b408b37a45f806cb
+)
+FetchContent_MakeAvailable(FMS)
+# add_subdirectory(FMS)
+
+list(APPEND CMAKE_MODULE_PATH ${FMS_SOURCE_DIR}/cmake)
+
+# Append directory that contains CMake Modules for building FMS and cFMS
+# list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/FMS/cmake)
+
+# set(TARGET_NAME libcFMS)
+
+list(APPEND cfms_src_files
+  c_constants/c_constants.F90
+  c_data_override/c_data_override.F90
+  c_diag_manager/c_diag_manager.F90
+  c_fms/c_fms.F90
+  c_fms_utils/c_fms_utils.F90
+  c_grid_utils/c_grid_utils.F90
+  c_horiz_interp/c_horiz_interp.F90
+)
+
+list(APPEND cfms_header_files
+  c_constants/c_constants.h
+  c_data_override/c_data_override.h
+  c_diag_manager/c_diag_manager.h
+  c_fms/c_fms.h
+  c_grid_utils/c_grid_utils.h
+  c_horiz_interp/c_horiz_interp.h
+)
+
+add_library(cFMS SHARED
+    ${cfms_src_files}
+)
+
+target_link_libraries(cFMS PUBLIC
+  FMS::fms
+)
+
+target_include_directories(cFMS PRIVATE
+  c_data_override/include
+  c_diag_manager/include
+  c_fms/include
+  c_fms_utils/include
+  c_horiz_interp/include
+#   FMS/include
+  ${CMAKE_SOURCE_DIR}/FMS/include
+)
+
+install(TARGETS cFMS
+    LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}
+)
+install(FILES ${cfms_header_files}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+
+
+
+
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 # Build options
 option(PORTABLE_KINDS "Enable compiler defition -DPORTABLE_KINDS" ON)
 option(WITH_YAML "Enable compiler definition -Duse_yaml" ON)
+option(CFMS_TESTS "Enable compiling of test scripts" OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include(FetchContent)
@@ -99,7 +100,9 @@ install(FILES ${cfms_header_files}
     DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
 
 # Tests
-
+if(CFMS_TESTS)
+    add_subdirectory(test_cfms)
+endif()
 
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,13 +47,13 @@ endif()
 
 # Find dependencies
 
-FetchContent_Declare(
-    FMS
-    GIT_REPOSITORY https://github.com/fmalatino/FMS.git
-    GIT_TAG optional_tests_cmake
-)
-FetchContent_MakeAvailable(FMS)
-# add_subdirectory(FMS)
+# FetchContent_Declare(
+#     FMS
+#     GIT_REPOSITORY https://github.com/fmalatino/FMS.git
+#     GIT_TAG optional_tests_cmake
+# )
+# FetchContent_MakeAvailable(FMS)
+add_subdirectory(FMS)
 
 list(APPEND cfms_src_files
   c_constants/c_constants.F90
@@ -89,8 +89,8 @@ target_include_directories(cFMS PRIVATE
   c_fms/include
   c_fms_utils/include
   c_horiz_interp/include
-#   FMS/include
-  ${CMAKE_SOURCE_DIR}/FMS/include
+  FMS/include
+#   ${CMAKE_SOURCE_DIR}/FMS/include
 )
 
 install(TARGETS cFMS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,13 +47,13 @@ endif()
 
 # Find dependencies
 
-# FetchContent_Declare(
-#     FMS
-#     GIT_REPOSITORY https://github.com/NOAA-GFDL/FMS.git
-#     GIT_TAG fbbe8f6abaae0b307951c023b408b37a45f806cb
-# )
-# FetchContent_MakeAvailable(FMS)
-add_subdirectory(FMS)
+FetchContent_Declare(
+    FMS
+    GIT_REPOSITORY https://github.com/fmalatino/FMS.git
+    GIT_TAG optional_tests_cmake
+)
+FetchContent_MakeAvailable(FMS)
+# add_subdirectory(FMS)
 
 list(APPEND cfms_src_files
   c_constants/c_constants.F90
@@ -89,8 +89,8 @@ target_include_directories(cFMS PRIVATE
   c_fms/include
   c_fms_utils/include
   c_horiz_interp/include
-  FMS/include
-  # ${CMAKE_SOURCE_DIR}/FMS/include
+#   FMS/include
+  ${CMAKE_SOURCE_DIR}/FMS/include
 )
 
 install(TARGETS cFMS
@@ -101,6 +101,7 @@ install(FILES ${cfms_header_files}
 
 # Tests
 if(CFMS_TESTS)
+    enable_testing()
     add_subdirectory(test_cfms)
 endif()
 

--- a/c_fms/c_fms.F90
+++ b/c_fms/c_fms.F90
@@ -222,7 +222,7 @@ contains
       integer, intent(in) :: npes
       integer, intent(in) :: pelist(npes)
       character(c_char), intent(in), optional :: name(NAME_LENGTH)
-      integer, intent(out), optional :: commID
+      integer, intent(out) :: commID
 
       character(len=NAME_LENGTH) :: name_f=" " !mpp default
 
@@ -252,7 +252,7 @@ contains
       integer, intent(in) :: npes
       integer, intent(out) :: pelist(npes)
       character(c_char), intent(out), optional :: name(NAME_LENGTH)
-      integer, intent(out), optional :: commID
+      integer, intent(out) :: commID
 
       character(len=NAME_LENGTH) :: name_f=" " !mpp default
 

--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -1,0 +1,337 @@
+# (C) Copyright 2011- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation nor
+# does it submit to any jurisdiction.
+
+# Try to find NetCDF includes and library.
+# Supports static and shared libaries and allows each component to be found in sepearte prefixes.
+#
+# This module defines
+#
+#   - NetCDF_FOUND                - System has NetCDF
+#   - NetCDF_INCLUDE_DIRS         - the NetCDF include directories
+#   - NetCDF_VERSION              - the version of NetCDF
+#   - NetCDF_CONFIG_EXECUTABLE    - the netcdf-config executable if found
+#   - NetCDF_PARALLEL             - Boolean True if NetCDF4 has parallel IO support via hdf5 and/or pnetcdf
+#   - NetCDF_HAS_PNETCDF          - Boolean True if NetCDF4 has pnetcdf support
+#
+# Deprecated Defines
+#   - NetCDF_LIBRARIES            - [Deprecated] Use NetCDF::NetCDF_<LANG> targets instead.
+#
+#
+# Following components are available:
+#
+#   - C                           - C interface to NetCDF          (netcdf)
+#   - CXX                         - CXX4 interface to NetCDF       (netcdf_c++4)
+#   - Fortran                     - Fortran interface to NetCDF    (netcdff)
+#
+# For each component the following are defined:
+#
+#   - NetCDF_<comp>_FOUND         - whether the component is found
+#   - NetCDF_<comp>_LIBRARIES     - the libraries for the component
+#   - NetCDF_<comp>_LIBRARY_SHARED - Boolean is true if libraries for component are shared
+#   - NetCDF_<comp>_INCLUDE_DIRS  - the include directories for specified component
+#   - NetCDF::NetCDF_<comp>       - target of component to be used with target_link_libraries()
+#
+# The following paths will be searched in order if set in CMake (first priority) or environment (second priority)
+#
+#   - NetCDF_ROOT                 - root of NetCDF installation
+#   - NetCDF_PATH                 - root of NetCDF installation
+#
+# The search process begins with locating NetCDF Include headers.  If these are in a non-standard location,
+# set one of the following CMake or environment variables to point to the location:
+#
+#  - NetCDF_INCLUDE_DIR or NetCDF_${comp}_INCLUDE_DIR
+#  - NetCDF_INCLUDE_DIRS or NetCDF_${comp}_INCLUDE_DIR
+#
+# Notes:
+#
+#   - Use "NetCDF::NetCDF_<LANG>" targets only.  NetCDF_LIBRARIES exists for backwards compatibility and should not be used.
+#     - These targets have all the knowledge of include directories and library search directories, and a single
+#       call to target_link_libraries will provide all these transitive properties to your target.  Normally all that is
+#       needed to build and link against NetCDF is, e.g.:
+#           target_link_libraries(my_c_tgt PUBLIC NetCDF::NetCDF_C)
+#   - "NetCDF" is always the preferred naming for this package, its targets, variables, and environment variables
+#     - For compatibility, some variables are also set/checked using alternate names NetCDF4, NETCDF, or NETCDF4
+#     - Environments relying on these older environment variable names should move to using a "NetCDF_ROOT" environment variable
+#   - Preferred component capitalization follows the CMake LANGUAGES variables: i.e., C, Fortran, CXX
+#     - For compatibility, alternate capitalizations are supported but should not be used.
+#   - If no components are defined, all components will be searched
+#
+
+list( APPEND _possible_components C CXX Fortran )
+
+## Include names for each component
+set( NetCDF_C_INCLUDE_NAME          netcdf.h )
+set( NetCDF_CXX_INCLUDE_NAME        netcdf )
+set( NetCDF_Fortran_INCLUDE_NAME    netcdf.mod )
+
+## Library names for each component
+set( NetCDF_C_LIBRARY_NAME          netcdf )
+set( NetCDF_CXX_LIBRARY_NAME        netcdf_c++4 )
+set( NetCDF_Fortran_LIBRARY_NAME    netcdff )
+
+## Enumerate search components
+foreach( _comp ${_possible_components} )
+  string( TOUPPER "${_comp}" _COMP )
+  set( _arg_${_COMP} ${_comp} )
+  set( _name_${_COMP} ${_comp} )
+endforeach()
+
+set( _search_components C)
+foreach( _comp ${${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS} )
+  string( TOUPPER "${_comp}" _COMP )
+  set( _arg_${_COMP} ${_comp} )
+  list( APPEND _search_components ${_name_${_COMP}} )
+  if( NOT _name_${_COMP} )
+    message(SEND_ERROR "Find${CMAKE_FIND_PACKAGE_NAME}: COMPONENT ${_comp} is not a valid component. Valid components: ${_possible_components}" )
+  endif()
+endforeach()
+list( REMOVE_DUPLICATES _search_components )
+
+## Search hints for finding include directories and libraries
+foreach( _comp IN ITEMS "_" "_C_" "_Fortran_" "_CXX_" )
+  foreach( _name IN ITEMS NetCDF4 NetCDF NETCDF4 NETCDF )
+    foreach( _var IN ITEMS ROOT PATH )
+      list(APPEND _search_hints ${${_name}${_comp}${_var}} $ENV{${_name}${_comp}${_var}} )
+      list(APPEND _include_search_hints
+                ${${_name}${_comp}INCLUDE_DIR} $ENV{${_name}${_comp}INCLUDE_DIR}
+                ${${_name}${_comp}INCLUDE_DIRS} $ENV{${_name}${_comp}INCLUDE_DIRS} )
+    endforeach()
+  endforeach()
+endforeach()
+#Old-school HPC module env variable names
+foreach( _name IN ITEMS NetCDF4 NetCDF NETCDF4 NETCDF )
+  foreach( _comp IN ITEMS "_C" "_Fortran" "_CXX" )
+    list(APPEND _search_hints ${${_name}}         $ENV{${_name}})
+    list(APPEND _search_hints ${${_name}${_comp}} $ENV{${_name}${_comp}})
+  endforeach()
+endforeach()
+
+## Find headers for each component
+set(NetCDF_INCLUDE_DIRS)
+set(_new_search_components)
+foreach( _comp IN LISTS _search_components )
+  if(NOT ${PROJECT_NAME}_NetCDF_${_comp}_FOUND)
+      list(APPEND _new_search_components ${_comp})
+  endif()
+  find_file(NetCDF_${_comp}_INCLUDE_FILE
+    NAMES ${NetCDF_${_comp}_INCLUDE_NAME}
+    DOC "NetCDF ${_comp} include directory"
+    HINTS ${_include_search_hints} ${_search_hints}
+    PATH_SUFFIXES include include/netcdf
+  )
+  mark_as_advanced(NetCDF_${_comp}_INCLUDE_FILE)
+  message(DEBUG "NetCDF_${_comp}_INCLUDE_FILE: ${NetCDF_${_comp}_INCLUDE_FILE}")
+  if( NetCDF_${_comp}_INCLUDE_FILE )
+    get_filename_component(NetCDF_${_comp}_INCLUDE_FILE ${NetCDF_${_comp}_INCLUDE_FILE} ABSOLUTE)
+    get_filename_component(NetCDF_${_comp}_INCLUDE_DIR ${NetCDF_${_comp}_INCLUDE_FILE} DIRECTORY)
+    list(APPEND NetCDF_INCLUDE_DIRS ${NetCDF_${_comp}_INCLUDE_DIR})
+  endif()
+endforeach()
+if(NetCDF_INCLUDE_DIRS)
+    list(REMOVE_DUPLICATES NetCDF_INCLUDE_DIRS)
+endif()
+set(NetCDF_INCLUDE_DIRS "${NetCDF_INCLUDE_DIRS}" CACHE STRING "NetCDF Include directory paths" FORCE)
+
+## Find n*-config executables for search components
+foreach( _comp IN LISTS _search_components )
+  if( _comp MATCHES "^(C)$" )
+    set(_conf "c")
+  elseif( _comp MATCHES "^(Fortran)$" )
+    set(_conf "f")
+  elseif( _comp MATCHES "^(CXX)$" )
+    set(_conf "cxx4")
+  endif()
+  find_program( NetCDF_${_comp}_CONFIG_EXECUTABLE
+      NAMES n${_conf}-config
+    HINTS ${NetCDF_INCLUDE_DIRS} ${_include_search_hints} ${_search_hints}
+    PATH_SUFFIXES bin Bin ../bin ../../bin
+      DOC "NetCDF n${_conf}-config helper" )
+    message(DEBUG "NetCDF_${_comp}_CONFIG_EXECUTABLE: ${NetCDF_${_comp}_CONFIG_EXECUTABLE}")
+endforeach()
+
+set(_C_libs_flag --libs)
+set(_Fortran_libs_flag --flibs)
+set(_CXX_libs_flag --libs)
+set(_C_includes_flag --includedir)
+set(_Fortran_includes_flag --includedir)
+set(_CXX_includes_flag --includedir)
+function(netcdf_config exec flag output_var)
+  set(${output_var} False PARENT_SCOPE)
+  if( exec )
+    execute_process( COMMAND ${exec} ${flag} RESULT_VARIABLE _ret OUTPUT_VARIABLE _val)
+    if( _ret EQUAL 0 )
+      string( STRIP ${_val} _val )
+      set( ${output_var} ${_val} PARENT_SCOPE )
+    endif()
+  endif()
+endfunction()
+
+## Find libraries for each component
+set( NetCDF_LIBRARIES )
+foreach( _comp IN LISTS _search_components )
+  string( TOUPPER "${_comp}" _COMP )
+
+  find_library( NetCDF_${_comp}_LIBRARY
+    NAMES ${NetCDF_${_comp}_LIBRARY_NAME}
+    DOC "NetCDF ${_comp} library"
+    HINTS ${NetCDF_${_comp}_INCLUDE_DIRS} ${_search_hints}
+    PATH_SUFFIXES lib64 lib ../lib64 ../lib ../../lib64 ../../lib )
+  mark_as_advanced( NetCDF_${_comp}_LIBRARY )
+  get_filename_component(NetCDF_${_comp}_LIBRARY ${NetCDF_${_comp}_LIBRARY} ABSOLUTE)
+  set(NetCDF_${_comp}_LIBRARY ${NetCDF_${_comp}_LIBRARY} CACHE STRING "NetCDF ${_comp} library" FORCE)
+  message(DEBUG "NetCDF_${_comp}_LIBRARY: ${NetCDF_${_comp}_LIBRARY}")
+
+  if( NetCDF_${_comp}_LIBRARY )
+    if( NetCDF_${_comp}_LIBRARY MATCHES ".a$" )
+      set( NetCDF_${_comp}_LIBRARY_SHARED FALSE )
+      set( _library_type STATIC)
+    else()
+      list( APPEND NetCDF_LIBRARIES ${NetCDF_${_comp}_LIBRARY} )
+      set( NetCDF_${_comp}_LIBRARY_SHARED TRUE )
+      set( _library_type SHARED)
+    endif()
+  endif()
+
+  #Use nc-config to set per-component LIBRARIES variable if possible
+  netcdf_config( ${NetCDF_${_comp}_CONFIG_EXECUTABLE} ${_${_comp}_libs_flag} _val )
+  if( _val )
+    set( NetCDF_${_comp}_LIBRARIES ${_val} )
+    if(NOT NetCDF_${_comp}_LIBRARY_SHARED AND NOT NetCDF_${_comp}_FOUND) #Static targets should use nc_config to get a proper link line with all necessary static targets.
+      list( APPEND NetCDF_LIBRARIES ${NetCDF_${_comp}_LIBRARIES} )
+    endif()
+  else()
+    set( NetCDF_${_comp}_LIBRARIES ${NetCDF_${_comp}_LIBRARY} )
+    if(NOT NetCDF_${_comp}_LIBRARY_SHARED)
+      message(SEND_ERROR "Unable to properly find NetCDF.  Found static libraries at: ${NetCDF_${_comp}_LIBRARY} but could not run nc-config: ${NetCDF_CONFIG_EXECUTABLE}")
+    endif()
+  endif()
+
+  #Use nc-config to set per-component INCLUDE_DIRS variable if possible
+  netcdf_config( ${NetCDF_${_comp}_CONFIG_EXECUTABLE} ${_${_comp}_includes_flag} _val )
+  if( _val )
+    string( REPLACE " " ";" _val ${_val} )
+    set( NetCDF_${_comp}_INCLUDE_DIRS ${_val} )
+  else()
+    set( NetCDF_${_comp}_INCLUDE_DIRS ${NetCDF_${_comp}_INCLUDE_DIR} )
+  endif()
+
+  if( NetCDF_${_comp}_LIBRARIES AND NetCDF_${_comp}_INCLUDE_DIRS )
+    set( ${CMAKE_FIND_PACKAGE_NAME}_${_arg_${_COMP}}_FOUND TRUE )
+    if (NOT TARGET NetCDF::NetCDF_${_comp})
+      add_library(NetCDF::NetCDF_${_comp} ${_library_type} IMPORTED)
+      set_target_properties(NetCDF::NetCDF_${_comp} PROPERTIES
+        IMPORTED_LOCATION ${NetCDF_${_comp}_LIBRARY}
+        INTERFACE_INCLUDE_DIRECTORIES "${NetCDF_${_comp}_INCLUDE_DIRS}"
+        INTERFACE_LINK_LIBRARIES ${NetCDF_${_comp}_LIBRARIES} )
+    endif()
+  endif()
+endforeach()
+if(NetCDF_LIBRARIES AND NetCDF_${_comp}_LIBRARY_SHARED)
+    list(REMOVE_DUPLICATES NetCDF_LIBRARIES)
+endif()
+set(NetCDF_LIBRARIES "${NetCDF_LIBRARIES}" CACHE STRING "NetCDF library targets" FORCE)
+
+## Find version via netcdf-config if possible
+if (NetCDF_INCLUDE_DIRS)
+  if( NetCDF_C_CONFIG_EXECUTABLE )
+    netcdf_config( ${NetCDF_C_CONFIG_EXECUTABLE} --version _vers )
+    if( _vers )
+      string(REGEX REPLACE ".* ((([0-9]+)\\.)+([0-9]+)).*" "\\1" NetCDF_VERSION "${_vers}" )
+    endif()
+  else()
+    foreach( _dir IN LISTS NetCDF_INCLUDE_DIRS)
+      if( EXISTS "${_dir}/netcdf_meta.h" )
+        file(STRINGS "${_dir}/netcdf_meta.h" _netcdf_version_lines
+        REGEX "#define[ \t]+NC_VERSION_(MAJOR|MINOR|PATCH|NOTE)")
+        string(REGEX REPLACE ".*NC_VERSION_MAJOR *\([0-9]*\).*" "\\1" _netcdf_version_major "${_netcdf_version_lines}")
+        string(REGEX REPLACE ".*NC_VERSION_MINOR *\([0-9]*\).*" "\\1" _netcdf_version_minor "${_netcdf_version_lines}")
+        string(REGEX REPLACE ".*NC_VERSION_PATCH *\([0-9]*\).*" "\\1" _netcdf_version_patch "${_netcdf_version_lines}")
+        string(REGEX REPLACE ".*NC_VERSION_NOTE *\"\([^\"]*\)\".*" "\\1" _netcdf_version_note "${_netcdf_version_lines}")
+        set(NetCDF_VERSION "${_netcdf_version_major}.${_netcdf_version_minor}.${_netcdf_version_patch}${_netcdf_version_note}")
+        unset(_netcdf_version_major)
+        unset(_netcdf_version_minor)
+        unset(_netcdf_version_patch)
+        unset(_netcdf_version_note)
+        unset(_netcdf_version_lines)
+      endif()
+    endforeach()
+  endif()
+endif ()
+
+## Detect additional package properties
+netcdf_config(${NetCDF_C_CONFIG_EXECUTABLE} --has-parallel4 _val)
+if( NOT _val MATCHES "^(yes|no)$" )
+  netcdf_config(${NetCDF_C_CONFIG_EXECUTABLE} --has-parallel _val)
+endif()
+if( _val MATCHES "^(yes)$" )
+  set(NetCDF_PARALLEL TRUE CACHE STRING "NetCDF has parallel IO capability via pnetcdf or hdf5." FORCE)
+else()
+  set(NetCDF_PARALLEL FALSE CACHE STRING "NetCDF has no parallel IO capability." FORCE)
+endif()
+
+## Finalize find_package
+include(FindPackageHandleStandardArgs)
+
+if(NOT NetCDF_FOUND OR _new_search_components)
+    find_package_handle_standard_args( ${CMAKE_FIND_PACKAGE_NAME}
+        REQUIRED_VARS NetCDF_INCLUDE_DIRS NetCDF_LIBRARIES
+        VERSION_VAR NetCDF_VERSION
+        HANDLE_COMPONENTS )
+endif()
+
+foreach( _comp IN LISTS _search_components )
+    if( NetCDF_${_comp}_FOUND )
+        #Record found components to avoid duplication in NetCDF_LIBRARIES for static libraries
+        set(NetCDF_${_comp}_FOUND ${NetCDF_${_comp}_FOUND} CACHE BOOL "NetCDF ${_comp} Found" FORCE)
+        #Set a per-package, per-component found variable to communicate between multiple calls to find_package()
+        set(${PROJECT_NAME}_NetCDF_${_comp}_FOUND True)
+    endif()
+endforeach()
+
+if( ${CMAKE_FIND_PACKAGE_NAME}_FOUND AND NOT ${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY AND _new_search_components)
+  message( STATUS "Find${CMAKE_FIND_PACKAGE_NAME} defines targets:" )
+  message( STATUS "  - NetCDF_VERSION [${NetCDF_VERSION}]")
+  message( STATUS "  - NetCDF_PARALLEL [${NetCDF_PARALLEL}]")
+  foreach( _comp IN LISTS _new_search_components )
+    string( TOUPPER "${_comp}" _COMP )
+    message( STATUS "  - NetCDF_${_comp}_CONFIG_EXECUTABLE [${NetCDF_${_comp}_CONFIG_EXECUTABLE}]")
+    if( ${CMAKE_FIND_PACKAGE_NAME}_${_arg_${_COMP}}_FOUND )
+      get_filename_component(_root ${NetCDF_${_comp}_INCLUDE_DIR}/.. ABSOLUTE)
+      if( NetCDF_${_comp}_LIBRARY_SHARED )
+        message( STATUS "  - NetCDF::NetCDF_${_comp} [SHARED] [Root: ${_root}] Lib: ${NetCDF_${_comp}_LIBRARY} ")
+      else()
+        message( STATUS "  - NetCDF::NetCDF_${_comp} [STATIC] [Root: ${_root}] Lib: ${NetCDF_${_comp}_LIBRARY} ")
+      endif()
+    endif()
+  endforeach()
+endif()
+
+foreach( _prefix NetCDF NetCDF4 NETCDF NETCDF4 ${CMAKE_FIND_PACKAGE_NAME} )
+  set( ${_prefix}_INCLUDE_DIRS ${NetCDF_INCLUDE_DIRS} )
+  set( ${_prefix}_LIBRARIES    ${NetCDF_LIBRARIES})
+  set( ${_prefix}_VERSION      ${NetCDF_VERSION} )
+  set( ${_prefix}_FOUND        ${${CMAKE_FIND_PACKAGE_NAME}_FOUND} )
+  set( ${_prefix}_CONFIG_EXECUTABLE ${NetCDF_CONFIG_EXECUTABLE} )
+  set( ${_prefix}_PARALLEL ${NetCDF_PARALLEL} )
+
+  foreach( _comp ${_search_components} )
+    string( TOUPPER "${_comp}" _COMP )
+    set( _arg_comp ${_arg_${_COMP}} )
+    set( ${_prefix}_${_comp}_FOUND     ${${CMAKE_FIND_PACKAGE_NAME}_${_arg_comp}_FOUND} )
+    set( ${_prefix}_${_COMP}_FOUND     ${${CMAKE_FIND_PACKAGE_NAME}_${_arg_comp}_FOUND} )
+    set( ${_prefix}_${_arg_comp}_FOUND ${${CMAKE_FIND_PACKAGE_NAME}_${_arg_comp}_FOUND} )
+
+    set( ${_prefix}_${_comp}_LIBRARIES     ${NetCDF_${_comp}_LIBRARIES} )
+    set( ${_prefix}_${_COMP}_LIBRARIES     ${NetCDF_${_comp}_LIBRARIES} )
+    set( ${_prefix}_${_arg_comp}_LIBRARIES ${NetCDF_${_comp}_LIBRARIES} )
+
+    set( ${_prefix}_${_comp}_INCLUDE_DIRS     ${NetCDF_${_comp}_INCLUDE_DIRS} )
+    set( ${_prefix}_${_COMP}_INCLUDE_DIRS     ${NetCDF_${_comp}_INCLUDE_DIRS} )
+    set( ${_prefix}_${_arg_comp}_INCLUDE_DIRS ${NetCDF_${_comp}_INCLUDE_DIRS} )
+  endforeach()
+endforeach()

--- a/test_cfms/CMakeLists.txt
+++ b/test_cfms/CMakeLists.txt
@@ -1,6 +1,28 @@
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test-lib.sh.in ${CMAKE_BINARY_DIR}/test-lib.sh @ONLY)
+
 add_subdirectory(c_data_override)
 add_subdirectory(c_diag_manager)
 add_subdirectory(c_fms)
 add_subdirectory(c_fms_utils)
 add_subdirectory(c_grid_utils)
 add_subdirectory(c_horiz_interp)
+
+file(GLOB_RECURSE TEST_SCRIPTS ${CMAKE_CURRENT_SOURCE_DIR}/*/*.sh)
+# leave out scripts that aren't tests
+list(FILTER TEST_SCRIPTS EXCLUDE REGEX "check_crashes.*")
+list(FILTER TEST_SCRIPTS EXCLUDE REGEX "test-lib*")
+list(FILTER TEST_SCRIPTS EXCLUDE REGEX "tap-driver.*")
+
+# add scripts to ctest
+foreach (testScript ${TEST_SCRIPTS})
+    get_filename_component(testName ${testScript} NAME_WE)
+    get_filename_component(testDirNameFull ${testScript} DIRECTORY)
+    get_filename_component(testDirName ${testDirNameFull} NAME_WE)
+    add_test(NAME ${testName}
+            COMMAND ${testScript}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    # all tests are labeled with directory name
+    set_property(TEST ${testName} PROPERTY LABELS ${testDirName})
+endforeach()
+
+set(CMAKE_CTEST_ARGUMENTS "--output-on-failure")

--- a/test_cfms/CMakeLists.txt
+++ b/test_cfms/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_subdirectory(c_data_override)
+add_subdirectory(c_diag_manager)
+# add_subdirectory(c_fms)
+# add_subdirectory(c_fms_utils)
+add_subdirectory(c_grid_utils)
+add_subdirectory(c_horiz_interp)

--- a/test_cfms/CMakeLists.txt
+++ b/test_cfms/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(c_data_override)
 add_subdirectory(c_diag_manager)
-# add_subdirectory(c_fms)
-# add_subdirectory(c_fms_utils)
+add_subdirectory(c_fms)
+add_subdirectory(c_fms_utils)
 add_subdirectory(c_grid_utils)
 add_subdirectory(c_horiz_interp)

--- a/test_cfms/c_data_override/CMakeLists.txt
+++ b/test_cfms/c_data_override/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_path(GET CMAKE_CURRENT_SOURCE_DIR PARENT_PATH PARENT_DIR)
+list(APPEND TEST_C_DATA_OVERRIDE_SRC
+    test_data_override_2d.c
+    test_data_override_3d.c
+    test_data_override_scalar.c
+)
+
+foreach (testfile ${TEST_C_DATA_OVERRIDE_SRC})
+    get_filename_component(testname ${testfile} NAME_WE)
+    add_executable(${testname} ${testfile} ${PARENT_DIR}/c_fms/c_mpp_domains_helper.c)
+    target_link_libraries(${testname} PUBLIC cFMS::cFMS)
+    target_include_directories(${testname} PUBLIC ${PARENT_DIR}/c_fms)
+endforeach()

--- a/test_cfms/c_data_override/CMakeLists.txt
+++ b/test_cfms/c_data_override/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_path(GET CMAKE_CURRENT_SOURCE_DIR PARENT_PATH PARENT_DIR)
 list(APPEND TEST_C_DATA_OVERRIDE_SRC
     test_data_override_2d.c
     test_data_override_3d.c
@@ -7,7 +6,10 @@ list(APPEND TEST_C_DATA_OVERRIDE_SRC
 
 foreach (testfile ${TEST_C_DATA_OVERRIDE_SRC})
     get_filename_component(testname ${testfile} NAME_WE)
-    add_executable(${testname} ${testfile} ${PARENT_DIR}/c_fms/c_mpp_domains_helper.c)
-    target_link_libraries(${testname} PUBLIC cFMS::cFMS)
-    target_include_directories(${testname} PUBLIC ${PARENT_DIR}/c_fms)
+    add_executable(${testname} ${testfile} ../c_fms/c_mpp_domains_helper.c)
+    target_link_libraries(${testname} PUBLIC cFMS)
+    target_include_directories(${testname} PUBLIC ../c_fms ../../c_fms ../../c_data_override)
 endforeach()
+
+add_executable(test_data_override_ongrid_cfms test_data_override_ongrid.F90)
+target_link_libraries(test_data_override_ongrid_cfms PUBLIC FMS::fms)

--- a/test_cfms/c_diag_manager/CMakeLists.txt
+++ b/test_cfms/c_diag_manager/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_path(GET CMAKE_CURRENT_SOURCE_DIR PARENT_PATH PARENT_DIR)
+
+add_executable(test_send_data test_send_data.c ../c_fms/c_mpp_domains_helper.c)
+target_link_libraries(test_send_data PUBLIC cFMS)
+target_include_directories(test_send_data PUBLIC ../c_fms ../../c_fms ../../c_diag_manager)

--- a/test_cfms/c_fms/CMakeLists.txt
+++ b/test_cfms/c_fms/CMakeLists.txt
@@ -21,14 +21,13 @@ list(APPEND C_TYPE
 
 foreach (type ${C_TYPE})
     add_executable(test_gather_c${type} c_mpp_domains_helper.c test_gather.c)
-    target_compile_definitions(test_gather_c${type} PRIVATE "CFMS_TEST_KIND_=\"${type}\"")
-    target_compile_definitions(test_gather_c${type} PRIVATE "CFMS_GATHER_1D_=\"cFMS_gather_1d_c${type}\"")
-    target_compile_definitions(test_gather_c${type} PRIVATE "CFMS_GATHER_PELIST_2D_=\"cFMS_gather_pelist_2d_c${type}\"")
-    target_compile_definitions(test_gather_c${type} PRIVATE "CFMS_GATHER_1D_=\"cFMS_gatherv_1d_c${type}\"")
+    target_compile_definitions(test_gather_c${type} PRIVATE "CFMS_TEST_KIND_=${type}")
+    target_compile_definitions(test_gather_c${type} PRIVATE "CFMS_GATHER_1D_=cFMS_gather_1d_c${type}")
+    target_compile_definitions(test_gather_c${type} PRIVATE "CFMS_GATHER_PELIST_2D_=cFMS_gather_pelist_2d_c${type}")
+    target_compile_definitions(test_gather_c${type} PRIVATE "CFMS_GATHERV_1D_=cFMS_gatherv_1d_c${type}")
     target_link_libraries(test_gather_c${type} PUBLIC cFMS)
     target_include_directories(test_gather_c${type} PUBLIC ../../c_fms ../c_fms)
 endforeach()
-
 
 add_executable(test_cfms test_cfms.c)
 target_link_libraries(test_cfms PUBLIC cFMS)

--- a/test_cfms/c_fms/CMakeLists.txt
+++ b/test_cfms/c_fms/CMakeLists.txt
@@ -1,0 +1,35 @@
+list(APPEND TEST_C_FMS_SRC
+    test_define_domains.c
+    test_getset_domains.c
+    test_update_domains.c
+    test_vector_update_domains.c
+    test_define_cubic_mosaic.c
+)
+
+foreach (testfile ${TEST_C_FMS_SRC})
+    get_filename_component(testname ${testfile} NAME_WE)
+    add_executable(${testname} ${testfile} c_mpp_domains_helper.c)
+    target_link_libraries(${testname} PUBLIC cFMS)
+    target_include_directories(${testname} PUBLIC ../../c_fms ../c_fms)
+endforeach()
+
+list(APPEND C_TYPE
+    int
+    float
+    double
+)
+
+foreach (type ${C_TYPE})
+    add_executable(test_gather_c${type} c_mpp_domains_helper.c test_gather.c)
+    target_compile_definitions(test_gather_c${type} PRIVATE "CFMS_TEST_KIND_=\"${type}\"")
+    target_compile_definitions(test_gather_c${type} PRIVATE "CFMS_GATHER_1D_=\"cFMS_gather_1d_c${type}\"")
+    target_compile_definitions(test_gather_c${type} PRIVATE "CFMS_GATHER_PELIST_2D_=\"cFMS_gather_pelist_2d_c${type}\"")
+    target_compile_definitions(test_gather_c${type} PRIVATE "CFMS_GATHER_1D_=\"cFMS_gatherv_1d_c${type}\"")
+    target_link_libraries(test_gather_c${type} PUBLIC cFMS)
+    target_include_directories(test_gather_c${type} PUBLIC ../../c_fms ../c_fms)
+endforeach()
+
+
+add_executable(test_cfms test_cfms.c)
+target_link_libraries(test_cfms PUBLIC cFMS)
+target_include_directories(test_cfms PUBLIC ../../c_fms)

--- a/test_cfms/c_fms/test_define_domains.c
+++ b/test_cfms/c_fms/test_define_domains.c
@@ -90,15 +90,17 @@ int main() {
   //get global pelist
   {
   int npes = cFMS_npes();
+  int comm_id;
   global_pelist = (int *)malloc(npes*sizeof(int));
-  cFMS_get_current_pelist(&npes, global_pelist, NULL, NULL);
+  cFMS_get_current_pelist(&npes, global_pelist, NULL, &comm_id);
   }
   
   //set coarse domain as tile=0
   {
     for(int i=0 ; i<coarse_npes; i++) coarse_pelist[i] = global_pelist[i];
     char name_coarse[NAME_LENGTH] = "test coarse pelist";
-    cFMS_declare_pelist(&coarse_npes, coarse_pelist, name_coarse, NULL);
+    int comm_id;
+    cFMS_declare_pelist(&coarse_npes, coarse_pelist, name_coarse, &comm_id);
 
     if(any(coarse_npes, coarse_pelist, cFMS_pe())) {
 
@@ -155,8 +157,9 @@ int main() {
   //set fine domain as tile=1
   {
     char name_fine[NAME_LENGTH] = "test fine pelist";
+    int comm_id;
     for(int i=0; i<fine_npes; i++) fine_pelist[i] = global_pelist[COARSE_NPES+i];
-    cFMS_declare_pelist(&fine_npes, fine_pelist, name_fine, NULL);
+    cFMS_declare_pelist(&fine_npes, fine_pelist, name_fine, &comm_id);
     
     if(any(FINE_NPES, fine_pelist, cFMS_pe())) {
       

--- a/test_cfms/c_fms_utils/CMakeLists.txt
+++ b/test_cfms/c_fms_utils/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(test_utils test_utils.F90 test_utils_c.c)
+target_link_libraries(test_utils PUBLIC cFMS)
+target_include_directories(test_utils PUBLIC ../../c_fms)

--- a/test_cfms/c_fms_utils/CMakeLists.txt
+++ b/test_cfms/c_fms_utils/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(test_utils test_utils.F90 test_utils_c.c)
 target_link_libraries(test_utils PUBLIC cFMS)
-target_include_directories(test_utils PUBLIC ../../c_fms)
+target_include_directories(test_utils PUBLIC ../../c_fms ${CMAKE_BINARY_DIR})

--- a/test_cfms/c_grid_utils/CMakeLists.txt
+++ b/test_cfms/c_grid_utils/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(test_grid_utils test_grid_utils.c)
+target_link_libraries(test_grid_utils PUBLIC cFMS)
+target_include_directories(test_grid_utils PUBLIC ../../c_constants ../../c_grid_utils)

--- a/test_cfms/c_horiz_interp/CMakeLists.txt
+++ b/test_cfms/c_horiz_interp/CMakeLists.txt
@@ -1,0 +1,31 @@
+add_executable(test_create_xgrid test_create_xgrid.c)
+
+target_link_libraries(test_create_xgrid PUBLIC cFMS)
+target_include_directories(test_create_xgrid PUBLIC 
+    ../../c_constants 
+    ../../c_grid_utils 
+    ../../c_horiz_interp 
+    ../../c_fms 
+    ../c_fms
+)
+
+add_executable(test_horiz_interp_new ../c_fms/c_mpp_domains_helper.c test_horiz_interp_new.c)
+target_link_libraries(test_horiz_interp_new PUBLIC cFMS)
+target_include_directories(test_horiz_interp_new PUBLIC 
+    ../../c_constants 
+    ../../c_grid_utils
+    ../../c_horiz_interp
+    ../../c_fms
+    ../c_fms
+)
+
+add_executable(test_horiz_interp_base test_horiz_interp_base.c)
+target_link_libraries(test_horiz_interp_base PUBLIC cFMS)
+target_include_directories(test_horiz_interp_base PUBLIC 
+    ../../c_constants 
+    ../../c_grid_utils
+    ../../c_horiz_interp
+    ../../c_fms
+    ../c_fms
+)
+


### PR DESCRIPTION
**Description**
This PR introduces a method for installing `cFMS` through `CMake`. This will enable changes within `pyFMS` to move away from the current install method, which relies on interrupting the `build` method of `setuptools` to run a shell script to install`FMS` and `cFMS`. A subsequent PR in `pyFMS` will change the build backend of the package to `scikit-build-core`, which allows for `CMake` based installations of extension modules for Python packages.

As is seen in the `CMakeLists.txt`, `FMS` can either be installed via a call to `FetchContent` or `add_subdirectory` methods of `CMake`. If the former is used, `FMS` would no longer be required as a submodule to `cFMS`, as it would be installed directly from its GitHub repository. The latter method was chosen for this PR given the current structure of the `cFMS` repository.

This PR should be reviewed after the merge of [PR 1850](https://github.com/NOAA-GFDL/FMS/pull/1850) in FMS, which will prevent the automatic building of the FMS unit tests.